### PR TITLE
Update ParsePage.cs

### DIFF
--- a/osafw-app/App_Code/fw/ParsePage.cs
+++ b/osafw-app/App_Code/fw/ParsePage.cs
@@ -1267,8 +1267,8 @@ namespace osafw
         // parse all `multilang` strings and replace to corresponding current language string
         private void parse_lang(ref string page)
         {
-            if (!lang_parse)
-                return; // don't parse langs if told so
+            if (!lang_parse || page == null)
+                return; // don't parse langs if told so or page is null to avoid Regex exception
 
             page = RX_LANG.Replace(page, lang_evaluator);
         }


### PR DESCRIPTION
Prevent regex exception on null input. I got it when the model for select didn't have an "iname" field before listSelectOptions was overridden. The reason was not clear until I traced and debugged every call in ParsePage. I'd much easier if I see a select with empty names in the browser.