### PR TITLE
prevent initial height downsizing

### DIFF
--- a/osafw-app/App_Data/template/common/textarea_autosize.html
+++ b/osafw-app/App_Data/template/common/textarea_autosize.html
@@ -1,6 +1,11 @@
 <script src="<~GLOBAL[ASSETS_URL]>/js/jquery.textarea_autosize.min.js"></script>
 <script>
 $(document).ready(function(){
-    $('.autoresize').textareaAutoSize();
+    var $autoresize = $('.autoresize')
+    //prevent textarea downsizing from the initial DOM height
+    $autoresize.each(function(){
+        $(this).css('min-height', $(this).outerHeight())
+    });
+    $autoresize.textareaAutoSize();
 });
 </script>


### PR DESCRIPTION
Previously, for example, if you set ```rows="5"``` and then start typing, the auto size plugin automatically shrinks the height to just one line and the whole page layout after the text jitters. Setting the initial ```min-height `` prevents this, but still allows the height auto-growing along with the content.