### PR TITLE
cache fix, f2single

### DIFF
--- a/osafw-app/App_Code/fw/FwCache.cs
+++ b/osafw-app/App_Code/fw/FwCache.cs
@@ -114,7 +114,7 @@ public class FwCache
         var plen = prefix.Length;
         foreach (string key in new ArrayList(request_cache.Keys))
         {
-            if (key.Substring(0, plen) == prefix)
+            if (key.Length > plen && key.Substring(0, plen) == prefix)
             {
                 request_cache.Remove(key);
             }

--- a/osafw-app/App_Code/fw/Utils.cs
+++ b/osafw-app/App_Code/fw/Utils.cs
@@ -256,6 +256,7 @@ public class Utils
 
         return 0;
     }
+
     public static long f2long(object AField)
     {
         if (AField == null) return 0;
@@ -264,6 +265,15 @@ public class Utils
             return result;
 
         return 0;
+    }
+
+    public static Single f2single(object AField)
+    {
+        if (AField == null) return 0f;
+        if (Single.TryParse(AField.ToString(), out Single result))
+            return result;
+
+        return 0f;
     }
 
     // convert to double, optionally throw error


### PR DESCRIPTION
1. Caught an exception when cleared all cache for prefix. When you try to clear against longer prefix, but have a record with a shorter one, like I had this in one request:
```
fwmodel.one.Users*1
fwmodel.one.ImportFiles*6
```

2. ```Utils.f2single()```, some lib functions/methods may have ```Single``` parameters, like the font size setting in Spire .PDF library.
