### PR TITLE
handle decimals for DB

### DIFF
--- a/osafw-app/App_Code/fw/DB.cs
+++ b/osafw-app/App_Code/fw/DB.cs
@@ -1158,6 +1158,8 @@ public class DB : IDisposable
             }
             else if (field_type == "float")
                 result = Utils.f2float(field_value);
+            else if (field_type == "decimal")
+                result = Utils.f2decimal(field_value);
             else
                 // string or other unknown value
                 result = field_value;
@@ -1561,6 +1563,8 @@ public class DB : IDisposable
             result = field_type;
         else if (field_type == "float")
             result = field_type;
+        else if (field_type == "decimal")
+            result = field_type;
         else
             result = "varchar";
 
@@ -1857,13 +1861,18 @@ public class DB : IDisposable
                 }
 
             case "real":
-            case "numeric":
-            case "decimal":
-            case "money":
-            case "smallmoney":
             case "float":
                 {
                     result = "float";
+                    break;
+                }
+
+            case "decimal":
+            case "numeric":
+            case "money":
+            case "smallmoney":
+                {
+                    result = "decimal";
                     break;
                 }
 
@@ -1905,11 +1914,12 @@ public class DB : IDisposable
             or (int)OleDbType.UnsignedBigInt => "int",
 
             (int)OleDbType.Double
-            or (int)OleDbType.Numeric
+            or (int)OleDbType.Single => "float",
+
+            (int)OleDbType.Numeric
             or (int)OleDbType.VarNumeric
-            or (int)OleDbType.Single
             or (int)OleDbType.Decimal
-            or (int)OleDbType.Currency => "float",
+            or (int)OleDbType.Currency => "decimal",
 
             (int)OleDbType.Date
             or (int)OleDbType.DBDate

--- a/osafw-app/App_Code/fw/FwController.cs
+++ b/osafw-app/App_Code/fw/FwController.cs
@@ -501,6 +501,8 @@ public abstract class FwController
                                 list_where_params[param_name] = Utils.f2long(s);
                             else if (ft == "float")
                                 list_where_params[param_name] = Utils.f2float(s);
+                            else if (ft == "decimal")
+                                list_where_params[param_name] = Utils.f2decimal(s);
                             else
                                 list_where_params[param_name] = s;
                         }

--- a/osafw-app/App_Code/fw/Utils.cs
+++ b/osafw-app/App_Code/fw/Utils.cs
@@ -267,6 +267,15 @@ public class Utils
         return 0;
     }
 
+    public static decimal f2decimal(object AField)
+    {
+        if (AField == null) return decimal.Zero;
+        if (decimal.TryParse(AField.ToString(), out decimal result))
+            return result;
+
+        return decimal.Zero;
+    }
+
     public static Single f2single(object AField)
     {
         if (AField == null) return 0f;


### PR DESCRIPTION
previously we treated numeric/decimals as floats, and it led to floating point issues, like 
saving "2.5358" to a DECIMAL(10,17) stored the "2.53580000000000005" value in DB.
Or, saving "2.5358000000000001" stored as "2.5358000000000000" because of the ```f2float``` conversion.
