### PR TITLE
error exception for json

### DIFF
--- a/osafw-app/App_Code/fw/FW.cs
+++ b/osafw-app/App_Code/fw/FW.cs
@@ -916,6 +916,9 @@ public class FW : IDisposable
     {
         if (!this.response.HasStarted) this.response.Headers["Cache-Control"]= cache_control;
 
+        if (this.FormErrors.Count > 0 && !ps.ContainsKey("ERR"))
+            ps["ERR"] = this.FormErrors; // add errors if any
+
         string format = this.getResponseExpectedFormat();
         if (format == "json")
         {
@@ -953,9 +956,6 @@ public class FW : IDisposable
             this.redirect((string)ps["_redirect"]);
             return; // no further processing
         }
-
-        if (this.FormErrors.Count > 0 && !ps.ContainsKey("ERR"))
-            ps["ERR"] = this.FormErrors; // add errors if any
 
         string layout;
         if (format == "pjax")
@@ -1370,7 +1370,7 @@ public class FW : IDisposable
             ps["is_dump"] = true;
             if (Ex != null)
                 ps["DUMP_STACK"] = Ex.ToString();
-            
+
             ps["DUMP_SQL"] = DB.last_sql;
             ps["DUMP_FORM"] = dumper(FORM);
             ps["DUMP_SESSION"] = dumper(context.Session);

--- a/osafw-app/App_Code/fw/FwController.cs
+++ b/osafw-app/App_Code/fw/FwController.cs
@@ -862,16 +862,7 @@ public abstract class FwController
         Hashtable ps = null;
         if (fw.isJsonExpected())
         {
-            //for json response - just respond success=false with any errors
-            var _json = new Hashtable()
-            {
-                {"success",false},
-                {"err_msg", ex.Message}
-            };
-            // add ERR field errors to response if any
-            if (fw.FormErrors.Count > 0)
-                _json["ERR"] = fw.FormErrors;
-            ps = new Hashtable() { { "_json", _json } };
+            throw ex; //re-throw exception
         }
         else
         {


### PR DESCRIPTION
Oleg, please take a look at this request. Earlier, when we threw an exception in the controller action, the message text and HTTP status code has been set in `FW::errMsg()`. In the latest framework version, I found that for JSON the error code is not set. Debugging the cause, I found a new `FWController::actionError()` method that is called from `FW::callController()` on Invocational Exception. I had to make these modifications to get the previous behavior. All `ps["_json"]` fields are already there in the `FW::errMsg()`, except for setting the form errors. In one project, I rely on HTTP status code when working with JSON requests,  so I expect `status = 500` on `ApplicationException`.