### PR TITLE
Update LookupManager.cs

### DIFF
--- a/osafw-app/App_Code/models/LookupManager.cs
+++ b/osafw-app/App_Code/models/LookupManager.cs
@@ -111,6 +111,12 @@ public class LookupManager : FwModel
             throw new ApplicationException("Wrong lookup table name");
         string id_fname = fw.model<LookupManagerTables>().getColumnId(defs);
 
+        //set nullable fields to NULL value if empty
+        Hashtable table_schema = db.tableSchemaFull(tname);
+        foreach (string fld_name in item.Keys.Cast<string>().ToArray())
+            if (Utils.isEmpty(item[fld_name]) && (string)((Hashtable)(table_schema[fld_name]))["is_nullable"] == "1")
+                item[fld_name] = null;
+
         // also we need include old fields into where just because id by sort is not robust enough
         var itemold = oneByTname(tname, id);
         // If Not defs["list_columns"] > "" Then
@@ -141,7 +147,9 @@ public class LookupManager : FwModel
         Hashtable item_save = new();
         foreach (string key in item.Keys)
         {
-            if (itemold[key].ToString() != item[key].ToString())
+            // additional null and old value empty string check to avoid SET to NULL constantly as we get empty string from DB for DBNull values
+            if ((item[key] == null && itemold[key].ToString() != "")
+                || (item[key] != null && itemold[key].ToString() != item[key].ToString()))
                 item_save[key] = item[key];
         }
         // logger("NEW SAVE")

--- a/osafw-app/App_Code/models/LookupManager.cs
+++ b/osafw-app/App_Code/models/LookupManager.cs
@@ -114,7 +114,7 @@ public class LookupManager : FwModel
         //set nullable fields to NULL value if empty
         Hashtable table_schema = db.tableSchemaFull(tname);
         foreach (string fld_name in item.Keys.Cast<string>().ToArray())
-            if (Utils.isEmpty(item[fld_name]) && (string)((Hashtable)(table_schema[fld_name]))["is_nullable"] == "1")
+            if (Utils.isEmpty(item[fld_name]) && Utils.f2int(((Hashtable)(table_schema[fld_name]))["is_nullable"]) == 1)
                 item[fld_name] = null;
 
         // also we need include old fields into where just because id by sort is not robust enough


### PR DESCRIPTION
Proposal. Set to `NULL` for nullable fields if empty value is passed. For instance, I have a `DECIMAL(5,2)` field that is nullable, and without this code it always sets `0.00` value in the DB.