### PR TITLE
Update fw.js

### DIFF
--- a/osafw-app/wwwroot/assets/js/fw.js
+++ b/osafw-app/wwwroot/assets/js/fw.js
@@ -178,7 +178,7 @@ window.fw={
 
     //autosubmit filter on change filter fields
     $(document).on('change', 'form[data-list-filter][data-autosubmit] [name^="f["]:input:visible:not([data-nosubmit])', function(){
-        this.form.submit();
+        $(this.form).trigger('submit');
     });
 
     //pager click via form filter submit so all filters applied


### PR DESCRIPTION
Vanilla JS doesn't trigger the "submit" event, on which advanced search fields logic is hooked before the form submission
https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
So, before, when using the Advanced Search and changing some filter, the Advanced Search fields were cleared after the filters resubmission. 
