### PR TITLE
Update Utils.cs

### DIFF
--- a/osafw-app/App_Code/fw/Utils.cs
+++ b/osafw-app/App_Code/fw/Utils.cs
@@ -488,7 +488,7 @@ public class Utils
             if (!is_first) result.Append(',');
 
             string str = Regex.Replace(row[fld] + "", @"[\n\r]+", " ");
-            str = str.Replace("\"", "\\\"");
+            str = str.Replace("\"", "\"\"");
             // check if string need to be quoted (if it contains " or ,)
             if (str.IndexOf("\"") > 0 || str.IndexOf(",") > 0)
             {


### PR DESCRIPTION
Proper CSV double quote quoting. As I see, the VB version has a proper quoting. It might be lost during the migration process.

Btw, why do we replace new lines with a space? CSV reference allows new lines, just quote the whole thing.
https://www.ietf.org/rfc/rfc4180.txt
Page 2, clause 6. 

Should I prepare a pull request to be fully confirmed to a CSV standard?