### PR TITLE
fix s3 upload delete

### DIFF
--- a/osafw-app/App_Code/models/Att.cs
+++ b/osafw-app/App_Code/models/Att.cs
@@ -131,7 +131,7 @@ public class Att : FwModel
     public int cleanupTmpUploads()
     {
         var rows = db.arrayp("select * from " + db.qid(table_name) +
-            @$" where add_time<DATEADD(hour, -48, getdate()) 
+            @$" where add_time<DATEADD(hour, -48, getdate())
                  and (status={db.qi(STATUS_UNDER_UPDATE)} or status={db.qi(STATUS_DELETED)} and iname like 'TMP#%')", DB.h());
         foreach (var row in rows)
             this.delete(Utils.f2int(row["id"]), true);
@@ -219,7 +219,8 @@ public class Att : FwModel
             var item = one(id);
             if (Utils.f2int(item["is_s3"]) == 1)
             {
-                fw.model<S3>().deleteObject(table_name + "/" + item["id"]);
+                //delete the whole folder for att, it will delete all files recursively
+                fw.model<S3>().deleteObject(table_name + "/" + item["id"] + "/");
             }
             else
             {
@@ -382,7 +383,7 @@ public class Att : FwModel
         return db.rowp(db.limit("SELECT a.* from " + db.qid(fw.model<AttLinks>().table_name) + " al, " + db.qid(table_name) + " a" +
             @$" WHERE al.fwentities_id=@fwentities_id
                   and al.item_id=@item_id
-                  and a.id=al.att_id 
+                  and a.id=al.att_id
                   {where}
                 order by a.id", 1), @params);
     }


### PR DESCRIPTION
Take a look at this fix:

- delete folder on "Att" Delete action
- S3 Root prefix fix on deletion
- subfolders recursive delete fix
  + subfolders are obtained in a dedicated loop (Prefixes)
  + subfolders can be actual objects with zero sizes if created without body and key name ending with "/". So I had to introduce `is_folder_check` parameter. I don't like the complexity of parameters and recursive calls. Probably we need to introduce  `DeleteObjectFullPath(string key)` and move the deletion logic there.
