### PR TITLE
Permanent cookie expiration date calculation fix

### DIFF
--- a/osafw-app/App_Code/models/Users.cs
+++ b/osafw-app/App_Code/models/Users.cs
@@ -644,13 +644,12 @@ public class Users : FwModel
     #region Permanent Login Cookies
     public string createPermCookie(int id)
     {
-        long curTS = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds();
         string cookieId = Utils.getRandStr(64);
         string hashed = Utils.sha256(cookieId);
         var fields = DB.h("cookie_id", hashed, "users_id", id);
         db.updateOrInsert(table_users_cookies, fields, DB.h("users_id", id));
 
-        Utils.createCookie(fw, PERM_COOKIE_NAME, cookieId, curTS + 60 * 60 * 24 * PERM_COOKIE_DAYS);
+        Utils.createCookie(fw, PERM_COOKIE_NAME, cookieId, 60 * 60 * 24 * PERM_COOKIE_DAYS);
 
         return cookieId;
     }


### PR DESCRIPTION
The issue was that expiration time in seconds added to the current timestamp and then one more time added to the Now.