### PR TITLE
Add FwExtensions with type conversion methods and mark old methods as obsolete

### DIFF
--- a/osafw-app/App_Code/fw/FwExtensions.cs
+++ b/osafw-app/App_Code/fw/FwExtensions.cs
@@ -1,0 +1,359 @@
+// Contains extension methods.
+//
+// Part of ASP.NET osa framework  www.osalabs.com/osafw/asp.net-core
+// (c) 2009-2021 Oleg Savchuk www.osalabs.com
+
+using System;
+using System.Collections;
+using System.Globalization;
+
+/// <summary>
+/// Provides extension methods for safe type conversions.
+/// </summary>
+public static class FwExtensions
+{
+    /// <summary>
+    /// Converts an object to a boolean.
+    /// <para>- <c>null</c> returns <c>false</c>.</para>
+    /// <para>- <c>bool</c> returns its own value.</para>
+    /// <para>- <c>ICollection</c> returns <c>true</c> if Count &gt; 0, otherwise <c>false</c>.</para>
+    /// <para>- A non-zero number returns <c>true</c>, zero returns <c>false</c>.</para>
+    /// <para>- Otherwise, tries <see cref="bool.TryParse"/></para>
+    /// </summary>
+    /// <param name="o">The object to convert to a boolean.</param>
+    /// <returns>The boolean value interpreted from <paramref name="o"/>.</returns>
+    public static bool toBool(this object o)
+    {
+        if (o is null)
+        {
+            return false;
+        }
+        if (o is bool b)
+        {
+            return b;
+        }
+        if (o is ICollection ic)
+        {
+            return ic.Count > 0;
+        }
+        if (o.toDouble() != 0.0)
+        {
+            return true;
+        }
+        if (bool.TryParse(o.toStr(), out bool result))
+        {
+            return result;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Converts an object to <see cref="DateTime"/> using the specified <paramref name="format"/> if provided.
+    /// If conversion fails, returns <see cref="DateTime.MinValue"/>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="format">If provided, <see cref="DateTime.TryParseExact(string,string[],IFormatProvider,DateTimeStyles,out DateTime)"/> is used.</param>
+    /// <returns>A <see cref="DateTime"/>, or <see cref="DateTime.MinValue"/> on failure.</returns>
+    public static DateTime toDate(this object o, string format = "")
+    {
+        if (o is null)
+        {
+            return DateTime.MinValue;
+        }
+        if (o is DateTime dt)
+        {
+            return dt;
+        }
+        return o.toStr().toDate(format);
+    }
+
+    /// <summary>
+    /// Converts a string to <see cref="DateTime"/> using the specified <paramref name="format"/> if provided.
+    /// If conversion fails, returns <see cref="DateTime.MinValue"/>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="format">If provided, <see cref="DateTime.TryParseExact(string,string[],IFormatProvider,DateTimeStyles,out DateTime)"/> is used.</param>
+    /// <returns>A <see cref="DateTime"/>, or <see cref="DateTime.MinValue"/> on failure.</returns>
+    public static DateTime toDate(this string s, string format = "")
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return DateTime.MinValue;
+        }
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            if (DateTime.TryParseExact(s, format, null, DateTimeStyles.None, out DateTime exactParsed))
+            {
+                return exactParsed;
+            }
+        }
+        if (DateTime.TryParse(s, out DateTime parsed))
+        {
+            return parsed;
+        }
+        return DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Converts an object to a nullable <see cref="DateTime"/> using the specified <paramref name="format"/> if provided.
+    /// If conversion fails, returns <c>null</c>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="format">If provided, <see cref="DateTime.TryParseExact(string,string[],IFormatProvider,DateTimeStyles,out DateTime)"/> is used.</param>
+    /// <returns>A <see cref="DateTime"/> value, or <c>null</c> on failure.</returns>
+    public static DateTime? toDateOrNull(this object o, string format = "")
+    {
+        if (o is null)
+        {
+            return null;
+        }
+        if (o is DateTime dt)
+        {
+            return dt;
+        }
+        return o.toStr().toDateOrNull(format);
+    }
+
+    /// <summary>
+    /// Converts a string to a nullable <see cref="DateTime"/> using the specified <paramref name="format"/> if provided.
+    /// If conversion fails, returns <c>null</c>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="format">If provided, <see cref="DateTime.TryParseExact(string,string[],IFormatProvider,DateTimeStyles,out DateTime)"/> is used.</param>
+    /// <returns>A <see cref="DateTime"/> value, or <c>null</c> on failure.</returns>
+    public static DateTime? toDateOrNull(this string s, string format = "")
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return null;
+        }
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            if (DateTime.TryParseExact(s, format, null, DateTimeStyles.None, out DateTime exactParsed))
+            {
+                return exactParsed;
+            }
+        }
+        if (DateTime.TryParse(s, out DateTime parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts an object to a <see cref="decimal"/>.  
+    /// If the object is already a <see cref="decimal"/>, it is returned directly.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A decimal representation of the object, or <paramref name="defaultValue"/>.</returns>
+    public static decimal toDecimal(this object o, decimal defaultValue = decimal.Zero)
+    {
+        if (o is null)
+        {
+            return defaultValue;
+        }
+        if (o is decimal d)
+        {
+            return d;
+        }
+        return o.toStr().toDecimal(defaultValue);
+    }
+
+    /// <summary>
+    /// Converts a string to a <see cref="decimal"/>.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A decimal, or <paramref name="defaultValue"/> if parsing fails.</returns>
+    public static decimal toDecimal(this string s, decimal defaultValue = decimal.Zero)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return defaultValue;
+        }
+        if (decimal.TryParse(s, out decimal result))
+        {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Converts an object to a <see cref="double"/>.  
+    /// If the object is already a <see cref="double"/>, it is returned directly.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A double representation of the object, or <paramref name="defaultValue"/>.</returns>
+    public static double toDouble(this object o, double defaultValue = 0.0)
+    {
+        if (o is null)
+        {
+            return defaultValue;
+        }
+        if (o is double d)
+        {
+            return d;
+        }
+        return o.toStr().toDouble(defaultValue);
+    }
+
+    /// <summary>
+    /// Converts a string to a <see cref="double"/>.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A double, or <paramref name="defaultValue"/> if parsing fails.</returns>
+    public static double toDouble(this string s, double defaultValue = 0.0)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return defaultValue;
+        }
+        if (double.TryParse(s, out double result))
+        {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Converts an object to a <see cref="float"/>.  
+    /// If the object is already a <see cref="float"/>, it is returned directly.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A float representation of the object, or <paramref name="defaultValue"/>.</returns>
+    public static float toFloat(this object o, float defaultValue = 0.0f)
+    {
+        if (o is null)
+        {
+            return defaultValue;
+        }
+        if (o is float f)
+        {
+            return f;
+        }
+        return o.toStr().toFloat(defaultValue);
+    }
+
+    /// <summary>
+    /// Converts a string to a <see cref="float"/>.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A float, or <paramref name="defaultValue"/> if parsing fails.</returns>
+    public static float toFloat(this string s, float defaultValue = 0.0f)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return defaultValue;
+        }
+        if (float.TryParse(s, out float result))
+        {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Converts an object to an <see cref="int"/>.  
+    /// If the object is already an <see cref="int"/>, it is returned directly.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/> (default is 0).
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>An integer representation of the object, or <paramref name="defaultValue"/>.</returns>
+    public static int toInt(this object o, int defaultValue = 0)
+    {
+        if (o is null)
+        {
+            return defaultValue;
+        }
+        if (o is int i)
+        {
+            return i;
+        }
+        return o.toStr().toInt(defaultValue);
+    }
+
+    /// <summary>
+    /// Converts a string to an <see cref="int"/>.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/> (default is 0).
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>An integer, or <paramref name="defaultValue"/> if parsing fails.</returns>
+    public static int toInt(this string s, int defaultValue = 0)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return defaultValue;
+        }
+        if (int.TryParse(s, out int result))
+        {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Converts an object to a <see cref="long"/>.  
+    /// If the object is already a <see cref="long"/>, it is returned directly.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A long representation of the object, or <paramref name="defaultValue"/>.</returns>
+    public static long toLong(this object o, long defaultValue = 0)
+    {
+        if (o is null)
+        {
+            return defaultValue;
+        }
+        if (o is long l)
+        {
+            return l;
+        }
+        return o.toStr().toLong(defaultValue);
+    }
+
+    /// <summary>
+    /// Converts a string to a <see cref="long"/>.  
+    /// If conversion fails, returns the specified <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <param name="defaultValue">The value returned if conversion fails.</param>
+    /// <returns>A long, or <paramref name="defaultValue"/> if parsing fails.</returns>
+    public static long toLong(this string s, long defaultValue = 0)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return defaultValue;
+        }
+        if (long.TryParse(s, out long result))
+        {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Converts any object to a string. Returns an empty string if <paramref name="o"/> is null.
+    /// </summary>
+    /// <param name="o">The object to convert.</param>
+    /// <returns>The string representation of the object, or an empty string if null.</returns>
+    public static string toStr(this object o)
+    {
+        return o?.ToString() ?? string.Empty;
+    }
+}

--- a/osafw-app/App_Code/fw/Utils.cs
+++ b/osafw-app/App_Code/fw/Utils.cs
@@ -207,85 +207,37 @@ public class Utils
     }
 
     #region toBool, toInt, toStr... isDate, isEmpty functions
-    /// <summary>
-    /// convert anything to bool, in case of error return false:
-    ///   null - false
-    ///   collections - true if not empty
-    ///   non-zero number - true
-    /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static bool toBool(object o)
-    {
-        if (o == null) return false;
-        if (o is bool b) return b;
-        if (o is ICollection ic) return ic.Count > 0; //for collections return true if not empty
-        if (toFloat(o) != 0) return true; //non-zero number is true
-        if (bool.TryParse(o.ToString(), out bool result))
-            return result;
-
-        return false;
-
-    }
-
-    [Obsolete("This method is deprecated, use toBool instead.")]
-    public static bool f2bool(object o)
-    {
-        return toBool(o);
-    }
 
     /// <summary>
-    /// convert anything to DateTime, in case of error return DateTime.MinValue:
+    /// This method is obsolete. Use <see cref="FwExtensions.toBool(object)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <param name="exact_format">if set - TryParseExact used, example: "yyyyMMddHHmm"</param>
-    /// <returns></returns>
-    public static DateTime toDate(object o, string exact_format = "")
-    {
-        if (o == null) return DateTime.MinValue;
-        if (o is DateTime dt) return dt;
-
-        if (!string.IsNullOrEmpty(exact_format) && DateTime.TryParseExact(o.ToString(), exact_format, null, System.Globalization.DateTimeStyles.None, out DateTime result))
-            return result;
-
-        if (DateTime.TryParse(o.ToString(), out DateTime result2))
-            return result2;
-
-        return DateTime.MinValue;
-    }
+    [Obsolete("This method is obsolete. Please use the 'toBool' extension method instead.")]
+    public static bool toBool(object o) => o.toBool();
 
     /// <summary>
-    /// Convert anything to DateTime, in case of error return null.
+    /// This method is obsolete. Use <see cref="FwExtensions.toBool(object)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <param name="exact_format">if set - TryParseExact used, example: "yyyyMMddHHmm"</param>
+    [Obsolete("This method is obsolete. Please use the 'toBool' extension method instead.")]
+    public static bool f2bool(object o) => o.toBool();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDate(object, string)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDate' extension method instead.")]
+    public static DateTime toDate(object o, string exact_format = "") => o.toDate(exact_format);
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDateOrNull(object, string)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDateOrNull' extension method instead.")]
     /// <returns></returns>
-    public static DateTime? toDateOrNull(object o, string exact_format = "")
-    {
-        if (o == null) return null;
-        if (o is DateTime dt) return dt;
+    public static DateTime? toDateOrNull(object o, string exact_format = "") => o.toDateOrNull(exact_format);
 
-        if (!string.IsNullOrEmpty(exact_format) && DateTime.TryParseExact(o.ToString(), exact_format, null, System.Globalization.DateTimeStyles.None, out DateTime result))
-            return result;
-
-        if (DateTime.TryParse(o.ToString(), out DateTime result2))
-            return result2;
-
-        return null;
-    }
-
-
-    [Obsolete("This method is deprecated, use toDate instead.")]
-    public static DateTime? f2date(object field)
-    {
-        if (field is DateTime dateTimeValue)
-            return dateTimeValue;
-
-        if (DateTime.TryParse(field?.ToString().Trim(), out DateTime parsedDate))
-            return parsedDate;
-
-        return null;
-    }
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDateOrNull(object, string)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDateOrNull' extension method instead.")]
+    public static DateTime? f2date(object field) => field.toDateOrNull();
 
     /// <summary>
     /// return true if field is date
@@ -294,122 +246,79 @@ public class Utils
     /// <returns></returns>
     public static bool isDate(object o)
     {
-        return toDateOrNull(o) != null;
+        return o.toDateOrNull() != null;
     }
 
     /// <summary>
-    /// convert anything to string (if cannot convert to string - just return empty string)
+    /// This method is obsolete. Use <see cref="FwExtensions.toStr(object)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static string toStr(object o)
-    {
-        if (o == null) return "";
-        return o.ToString();
-    }
-
-    [Obsolete("This method is deprecated, use toStr instead.")]
-    public static string f2str(object field)
-    {
-        return toStr(field);
-    }
+    [Obsolete("This method is obsolete. Please use the 'toStr' extension method instead.")]
+    public static string toStr(object o) => o.toStr();
 
     /// <summary>
-    /// convert anything to int, in case of error return 0:
+    /// This method is obsolete. Use <see cref="FwExtensions.toStr(object)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static int toInt(object o)
-    {
-        if (o == null) return 0;
-        if (o is int i) return i;
-        if (int.TryParse(o.ToString(), out int result))
-            return result;
-
-        return 0;
-    }
-
-    [Obsolete("This method is deprecated, use toInt instead.")]
-    public static int f2int(object AField)
-    {
-        return toInt(AField);
-    }
-
-    public static long toLong(object o)
-    {
-        if (o == null) return 0;
-        if (o is long l) return l;
-        if (long.TryParse(o.ToString(), out long result))
-            return result;
-
-        return 0;
-    }
-
-    [Obsolete("This method is deprecated, use toLong instead.")]
-    public static long f2long(object AField)
-    {
-        return toLong(AField);
-    }
+    [Obsolete("This method is obsolete. Please use the 'toStr' extension method instead.")]
+    public static string f2str(object field) => field.toStr();
 
     /// <summary>
-    /// convert anything to decimal, in case of error return 0:
+    /// This method is obsolete. Use <see cref="FwExtensions.toInt(object, int)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static decimal toDecimal(object o)
-    {
-        if (o == null) return decimal.Zero;
-        if (o is decimal d) return d;
-        if (decimal.TryParse(o.ToString(), out decimal result))
-            return result;
-
-        return decimal.Zero;
-    }
-
-    [Obsolete("This method is deprecated, use toDecimal instead.")]
-    public static decimal f2decimal(object AField)
-    {
-        return toDecimal(AField);
-    }
+    [Obsolete("This method is obsolete. Please use the 'toInt' extension method instead.")]
+    public static int toInt(object o) => o.toInt();
 
     /// <summary>
-    /// convert anything to single, in case of error return 0:
+    /// This method is obsolete. Use <see cref="FwExtensions.toInt(object, int)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static Single toSingle(object o)
-    {
-        if (o == null) return 0f;
-        if (o is Single s) return s;
-        if (Single.TryParse(o.ToString(), out Single result))
-            return result;
-
-        return 0f;
-    }
-
-    [Obsolete("This method is deprecated, use toSingle instead.")]
-    public static Single f2single(object AField)
-    {
-        return toSingle(AField);
-    }
+    [Obsolete("This method is obsolete. Please use the 'toInt' extension method instead.")]
+    public static int f2int(object AField) => AField.toInt();
 
     /// <summary>
-    /// convert anything to double, in case of error return 0:
+    /// This method is obsolete. Use <see cref="FwExtensions.toLong(object, long)"/> instead.
     /// </summary>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public static double toFloat(object o)
-    {
-        if (o == null) return 0.0;
-        if (o is double d) return d;
-        if (double.TryParse(o.ToString(), out double result))
-            return result;
+    [Obsolete("This method is obsolete. Please use the 'toLong' extension method instead.")]
+    public static long toLong(object o) => o.toLong();
 
-        return 0.0;
-    }
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toLong(object, long)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toLong' extension method instead.")]
+    public static long f2long(object AField) => AField.toLong();
 
-    // convert to double, optionally throw error
-    [Obsolete("This method is deprecated, use toFloat instead.")]
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDecimal(object, decimal)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDecimal' extension method instead.")]
+    public static decimal toDecimal(object o) => o.toDecimal();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDecimal(object, decimal)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDecimal' extension method instead.")]
+    public static decimal f2decimal(object AField) => AField.toDecimal();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toFloat(object, float)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toFloat' extension method instead.")]
+    public static Single toSingle(object o) => o.toFloat();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toFloat(object, float)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toFloat' extension method instead.")]
+    public static Single f2single(object AField) => AField.toFloat();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDouble(object, double)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDouble' extension method instead.")]
+    public static double toFloat(object o) => o.toDouble();
+
+    /// <summary>
+    /// This method is obsolete. Use <see cref="FwExtensions.toDouble(object, double)"/> instead.
+    /// </summary>
+    [Obsolete("This method is obsolete. Please use the 'toDouble' extension method instead.")]
     public static double f2float(object AField, bool is_error = false)
     {
         if (AField == null && !is_error) return 0.0;
@@ -510,7 +419,7 @@ public class Utils
     {
         Hashtable mime_map = qh(MIME_MAP);
         ext = ext.ToLower(); //to lower
-        //remove first dot if any
+                             //remove first dot if any
         if (ext.StartsWith('.'))
             ext = ext[1..];
 

--- a/osafw-tests/App_Code/fw/FwExtensionsTests.cs
+++ b/osafw-tests/App_Code/fw/FwExtensionsTests.cs
@@ -1,0 +1,421 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace osafw.Tests
+{
+    [TestClass]
+    public class FwExtensionsTests
+    {
+        #region toBool
+
+        [TestMethod]
+        public void toBool_Null_ReturnsFalse()
+        {
+            object input = null;
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_BoolTrue_ReturnsTrue()
+        {
+            object input = true;
+            Assert.IsTrue(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_BoolFalse_ReturnsFalse()
+        {
+            object input = false;
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_ICollection_Empty_ReturnsFalse()
+        {
+            // List implementing ICollection with count=0
+            ICollection<int> input = new List<int>();
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_ICollection_NonEmpty_ReturnsTrue()
+        {
+            ICollection<int> input = new List<int> { 1, 2 };
+            Assert.IsTrue(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_ZeroAsNumber_ReturnsFalse()
+        {
+            object input = 0;
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_NonZeroAsNumber_ReturnsTrue()
+        {
+            object input = 42;
+            Assert.IsTrue(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_ZeroAsString_ReturnsFalse()
+        {
+            object input = "0";
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_NonZeroAsString_ReturnsTrue()
+        {
+            object input = "123";
+            Assert.IsTrue(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_TrueString_ReturnsTrue()
+        {
+            object input = "true";
+            Assert.IsTrue(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_FalseString_ReturnsFalse()
+        {
+            object input = "false";
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_InvalidString_ReturnsFalse()
+        {
+            object input = "not_a_bool";
+            Assert.IsFalse(input.toBool());
+        }
+
+        [TestMethod]
+        public void toBool_EmptyString_ReturnsFalse()
+        {
+            object input = "";
+            Assert.IsFalse(input.toBool());
+        }
+
+        #endregion
+
+        #region toDate / toDateOrNull
+
+        [TestMethod]
+        public void toDate_Null_ReturnsMinValue()
+        {
+            object input = null;
+            Assert.AreEqual(DateTime.MinValue, input.toDate());
+        }
+
+        [TestMethod]
+        public void toDate_AlreadyDateTime_ReturnsSameValue()
+        {
+            var now = DateTime.Now;
+            object input = now;
+            Assert.AreEqual(now, input.toDate());
+        }
+
+        [TestMethod]
+        public void toDate_StringValidDefaultFormat_ReturnsParsed()
+        {
+            var expected = new DateTime(2025, 1, 2);
+            // The exact result depends on your local culture/timezone if no style is specified
+            object input = expected.Date.ToShortDateString();
+            var result = input.toDate();
+            Assert.AreEqual(new DateTime(2025, 1, 2), result.Date);
+        }
+
+        [TestMethod]
+        public void toDate_StringValidExactFormat_ReturnsParsed()
+        {
+            object input = "2025-01-02";
+            var result = input.toDate("yyyy-MM-dd");
+            Assert.AreEqual(new DateTime(2025, 1, 2), result);
+        }
+
+        [TestMethod]
+        public void toDate_StringInvalidNoFormat_ReturnsMinValue()
+        {
+            object input = "invalid_date";
+            var result = input.toDate();
+            Assert.AreEqual(DateTime.MinValue, result);
+        }
+
+        [TestMethod]
+        public void toDateOrNull_Null_ReturnsNull()
+        {
+            object input = null;
+            Assert.IsNull(input.toDateOrNull());
+        }
+
+        [TestMethod]
+        public void toDateOrNull_AlreadyDateTime_ReturnsSameValue()
+        {
+            var now = DateTime.Now;
+            object input = now;
+            DateTime? result = input.toDateOrNull();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(now, result.Value);
+        }
+
+        [TestMethod]
+        public void toDateOrNull_StringValidDefault_ReturnsParsed()
+        {
+            var expected = new DateTime(2025, 1, 2);
+            // The exact result depends on your local culture/timezone if no style is specified
+            object input = expected.Date.ToShortDateString();
+            var result = input.toDateOrNull();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new DateTime(2025, 1, 2), result.Value);
+        }
+
+        [TestMethod]
+        public void toDateOrNull_StringValidExact_ReturnsParsed()
+        {
+            object input = "2025-01-02";
+            var result = input.toDateOrNull("yyyy-MM-dd");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new DateTime(2025, 1, 2), result.Value);
+        }
+
+        [TestMethod]
+        public void toDateOrNull_StringInvalidNoFormat_ReturnsNull()
+        {
+            object input = "invalid_date";
+            var result = input.toDateOrNull();
+            Assert.IsNull(result);
+        }
+
+        #endregion
+
+        #region toDecimal
+
+        [TestMethod]
+        public void toDecimal_Null_ReturnsDefault()
+        {
+            object input = null;
+            Assert.AreEqual(0m, input.toDecimal());
+        }
+
+        [TestMethod]
+        public void toDecimal_AlreadyDecimal_ReturnsSameValue()
+        {
+            decimal dec = 123.456m;
+            object input = dec;
+            Assert.AreEqual(dec, input.toDecimal());
+        }
+
+        [TestMethod]
+        public void toDecimal_ValidString_ReturnsParsed()
+        {
+            object input = "123.45";
+            Assert.AreEqual(123.45m, input.toDecimal());
+        }
+
+        [TestMethod]
+        public void toDecimal_InvalidString_ReturnsDefault()
+        {
+            object input = "invalid";
+            Assert.AreEqual(999m, input.toDecimal(999m));
+        }
+
+        [TestMethod]
+        public void toDecimal_EmptyString_ReturnsDefault()
+        {
+            object input = "";
+            Assert.AreEqual(0m, input.toDecimal());
+        }
+
+        #endregion
+
+        #region toDouble
+
+        [TestMethod]
+        public void toDouble_Null_ReturnsDefault()
+        {
+            object input = null;
+            Assert.AreEqual(0.0, input.toDouble());
+        }
+
+        [TestMethod]
+        public void toDouble_AlreadyDouble_ReturnsSameValue()
+        {
+            double d = 123.456;
+            object input = d;
+            Assert.AreEqual(d, input.toDouble());
+        }
+
+        [TestMethod]
+        public void toDouble_ValidString_ReturnsParsed()
+        {
+            object input = "123.45";
+            Assert.AreEqual(123.45, input.toDouble());
+        }
+
+        [TestMethod]
+        public void toDouble_InvalidString_ReturnsDefault()
+        {
+            object input = "invalid";
+            Assert.AreEqual(999.99, input.toDouble(999.99));
+        }
+
+        [TestMethod]
+        public void toDouble_EmptyString_ReturnsDefault()
+        {
+            object input = "";
+            Assert.AreEqual(0.0, input.toDouble());
+        }
+
+        #endregion
+
+        #region toFloat
+
+        [TestMethod]
+        public void toFloat_Null_ReturnsDefault()
+        {
+            object input = null;
+            Assert.AreEqual(0.0f, input.toFloat());
+        }
+
+        [TestMethod]
+        public void toFloat_AlreadyFloat_ReturnsSameValue()
+        {
+            float f = 123.456f;
+            object input = f;
+            Assert.AreEqual(f, input.toFloat());
+        }
+
+        [TestMethod]
+        public void toFloat_ValidString_ReturnsParsed()
+        {
+            object input = "123.45";
+            Assert.AreEqual(123.45f, input.toFloat(), 0.00001f);
+        }
+
+        [TestMethod]
+        public void toFloat_InvalidString_ReturnsDefault()
+        {
+            object input = "invalid";
+            Assert.AreEqual(999.99f, input.toFloat(999.99f), 0.00001f);
+        }
+
+        [TestMethod]
+        public void toFloat_EmptyString_ReturnsDefault()
+        {
+            object input = "";
+            Assert.AreEqual(0.0f, input.toFloat());
+        }
+
+        #endregion
+
+        #region toInt
+
+        [TestMethod]
+        public void toInt_Null_ReturnsDefault()
+        {
+            object input = null;
+            Assert.AreEqual(0, input.toInt());
+        }
+
+        [TestMethod]
+        public void toInt_AlreadyInt_ReturnsSameValue()
+        {
+            int i = 123;
+            object input = i;
+            Assert.AreEqual(i, input.toInt());
+        }
+
+        [TestMethod]
+        public void toInt_ValidString_ReturnsParsed()
+        {
+            object input = "123";
+            Assert.AreEqual(123, input.toInt());
+        }
+
+        [TestMethod]
+        public void toInt_InvalidString_ReturnsDefault()
+        {
+            object input = "invalid";
+            Assert.AreEqual(999, input.toInt(999));
+        }
+
+        [TestMethod]
+        public void toInt_EmptyString_ReturnsDefault()
+        {
+            object input = "";
+            Assert.AreEqual(0, input.toInt());
+        }
+
+        #endregion
+
+        #region toLong
+
+        [TestMethod]
+        public void toLong_Null_ReturnsDefault()
+        {
+            object input = null;
+            Assert.AreEqual(0L, input.toLong());
+        }
+
+        [TestMethod]
+        public void toLong_AlreadyLong_ReturnsSameValue()
+        {
+            long l = 123456789;
+            object input = l;
+            Assert.AreEqual(l, input.toLong());
+        }
+
+        [TestMethod]
+        public void toLong_ValidString_ReturnsParsed()
+        {
+            object input = "123456789";
+            Assert.AreEqual(123456789L, input.toLong());
+        }
+
+        [TestMethod]
+        public void toLong_InvalidString_ReturnsDefault()
+        {
+            object input = "invalid";
+            Assert.AreEqual(999999L, input.toLong(999999L));
+        }
+
+        [TestMethod]
+        public void toLong_EmptyString_ReturnsDefault()
+        {
+            object input = "";
+            Assert.AreEqual(0L, input.toLong());
+        }
+
+        #endregion
+
+        #region toStr
+
+        [TestMethod]
+        public void toStr_Null_ReturnsEmpty()
+        {
+            object input = null;
+            Assert.AreEqual(string.Empty, input.toStr());
+        }
+
+        [TestMethod]
+        public void toStr_NonNullObject_ReturnsToString()
+        {
+            object input = 123;
+            Assert.AreEqual("123", input.toStr());
+        }
+
+        [TestMethod]
+        public void toStr_EmptyString_ReturnsEmpty()
+        {
+            object input = "";
+            Assert.AreEqual("", input.toStr());
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
- Implement new `FwExtensions` class containing `.toInt()`, `.toLong()`, `.toFloat()`, `.toDouble()`, `.toDecimal()`, etc.
- Cover new extension methods with unit tests in `FwExtensionsTests`.
- Mark legacy conversion methods as `[Obsolete]` and reference new methods.