### PR TITLE
Replace wkhtmltopdf with Playwright for PDF Generation

### DIFF
--- a/osafw-app/App_Code/fw/ConvUtils.cs
+++ b/osafw-app/App_Code/fw/ConvUtils.cs
@@ -80,7 +80,7 @@ public class ConvUtils
             var pdfOptions = new PagePdfOptions
             {
                 Path = filename,
-                Format = "A4",
+                Format = "Letter",
                 PrintBackground = true,
                 Margin = new Margin
                 {

--- a/osafw-app/App_Code/fw/ConvUtils.cs
+++ b/osafw-app/App_Code/fw/ConvUtils.cs
@@ -1,13 +1,13 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using Microsoft.Playwright;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-
-// see also http://stackoverflow.com/questions/1331926/calling-wkhtmltopdf-to-generate-pdf-from-html/1698839#1698839
+using System.Threading.Tasks;
 
 namespace osafw;
 
@@ -32,17 +32,12 @@ public class ConvUtils
 
         html_data = _replace_specials(html_data);
 
-        string html_file = Utils.getTmpFilename() + ".html";
         string pdf_file = Utils.getTmpFilename() + ".pdf";
-        // fw.logger("INFO", "html file = " & html_file)
         // fw.logger("INFO", "pdf file = " & pdf_file)
-
-        // remove_old_files()
-        FW.setFileContent(html_file, ref html_data);
 
         if (string.IsNullOrEmpty(out_filename) || !Regex.IsMatch(out_filename, @"[\/\\]"))
         {
-            html2pdf(fw, html_file, pdf_file, options);
+            html2pdf(fw, html_data, pdf_file, options).GetAwaiter().GetResult();
 
             if (string.IsNullOrEmpty(out_filename))
             {
@@ -52,50 +47,69 @@ public class ConvUtils
             Utils.cleanupTmpFiles(); // this will cleanup temporary .pdf, can't delete immediately as file_response may not yet finish transferring file
         }
         else
-            html2pdf(fw, html_file, out_filename, options);
-        // remove tmp html file
-        File.Delete(html_file);
+        {
+            html2pdf(fw, html_data, out_filename, options).GetAwaiter().GetResult();
+        }
 
         return html_data;
     }
 
-    // !uses CONF var FW.config("pdf_converter") for converted command line
-    // !and FW.config("pdf_converter_args") - MUST include %IN %OUT which will be replaced by input and output file paths accordingly
-    // TODO: example: FW.config("html_converter_args")=" -po Landscape" - for landscape mode
-    // all params for TotalHTMLConverter: http://www.coolutils.com/help/TotalHTMLConverter/Commandlineparameters.php
-    // all params for WkHTMLtoPDF: http://wkhtmltopdf.org/usage/wkhtmltopdf.txt
     // options:
     // landscape = True - will produce landscape output
-    public static void html2pdf(FW fw, string htmlfile, string filename, Hashtable options = null)
+    public static async Task html2pdf(FW fw, string html_data, string filename, Hashtable options = null)
     {
-        if (htmlfile.Length < 1 | filename.Length < 1)
+        if (filename.Length < 1)
+        {
             throw new ApplicationException("Wrong filename");
-        System.Diagnostics.ProcessStartInfo info = new();
-        System.Diagnostics.Process process = new();
+        }
 
-        string cmdline = (string)FwConfig.settings["pdf_converter_args"];
-        cmdline = cmdline.Replace("%IN", "\"" + htmlfile + "\"");
-        cmdline = cmdline.Replace("%OUT", "\"" + filename + "\"");
-        if (options != null && options["landscape"].toBool())
+        try
         {
-            cmdline = " -O Landscape " + cmdline;
-        }
-        if (options != null && options.ContainsKey("cmd"))
-        {
-            cmdline = options["cmd"] + " " + cmdline;
-        }
-        info.FileName = (string)FwConfig.settings["pdf_converter"];
-        info.Arguments = cmdline;
+            using var playwright = await Playwright.CreateAsync();
+            await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true,
+                Channel = "chromium"
+            });
 
-        fw.logger(LogLevel.DEBUG, "exec: ", info.FileName, " ", info.Arguments);
-        process.StartInfo = info;
-        process.Start();
-        process.WaitForExit();
-        if (process.ExitCode != 0)
-        {
-            fw.logger(LogLevel.ERROR, "Exit code:", process.ExitCode);
+            var context = await browser.NewContextAsync();
+            var page = await context.NewPageAsync();
+
+            await page.SetContentAsync(html_data);
+
+            var pdfOptions = new PagePdfOptions
+            {
+                Path = filename,
+                Format = "A4",
+                PrintBackground = true,
+                Margin = new Margin
+                {
+                    Top = "5mm",
+                    Right = "10mm",
+                    Bottom = "5mm",
+                    Left = "10mm"
+                },
+                Landscape = false,
+                Scale = 0.8f,
+                DisplayHeaderFooter = false,
+                HeaderTemplate = string.Empty,
+                FooterTemplate = string.Empty,
+                PreferCSSPageSize = false,
+                Tagged = true
+            };
+
+            if (options is not null && options["landscape"].toBool())
+            {
+                pdfOptions.Landscape = true;
+            }
+
+            await page.PdfAsync(pdfOptions);
         }
-        process.Close();
+        catch (Exception ex)
+        {
+            fw.logger(LogLevel.ERROR, "PDF generation failed: ", ex.Message);
+            throw;
+        }
     }
 
     // TODO - currently it just parse html and save it under .doc extension (Word capable opening it), but need redo with real converter

--- a/osafw-app/App_Data/template/dev/manage/docs/tab_installation.md
+++ b/osafw-app/App_Data/template/dev/manage/docs/tab_installation.md
@@ -74,5 +74,4 @@
     - Configure the connection string for your database and SMTP settings.
 
 ### Optional Components
-- **Install wkhtmltopdf** for PDF report generation from [this link](https://wkhtmltopdf.org/downloads.html).
 - **Install ACE.OLEDB.12** to work with Access databases from [this link](https://download.microsoft.com/download/2/4/3/24375141-E08D-4803-AB0E-10F2E3A07AAA/AccessDatabaseEngine_X64.exe).

--- a/osafw-app/Program.cs
+++ b/osafw-app/Program.cs
@@ -23,6 +23,21 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        // Install Playwright full headless Chromium build on first run.
+        // The installer will detect existing binaries and skip re-downloading,
+        // making this safe to run every time the application starts.
+        // Additionally, if you update or downgrade the Microsoft.Playwright package,
+        // the installer will remove any out-of-sync Chromium versions and
+        // install the browser binary matching the library version,
+        // ensuring compatibility between Playwright and the browser.
+        Microsoft.Playwright.Program.Main(
+        [
+            "install",          // invoke Playwright installer
+            "chromium",         // install the full Chromium build
+            "--with-deps",      // include OS-level dependencies
+            "--no-shell"        // skip the legacy headless shell
+        ]);
+
         // In .NET 6+ the recommended pattern is the "WebApplication.CreateBuilder" approach
         var builder = WebApplication.CreateBuilder(args);
 

--- a/osafw-app/appsettings.json
+++ b/osafw-app/appsettings.json
@@ -92,9 +92,6 @@
     "ui_theme": 0,
     "ui_mode": 0,
 
-    "pdf_converter": "C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe",
-    "pdf_converter_args": "%IN %OUT",
-
     "lang": "en",
     "is_lang_update": false,
 

--- a/osafw-app/osafw-app.csproj
+++ b/osafw-app/osafw-app.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageReference Include="Markdig" Version="0.41.1" />
+	<PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="9.0.5" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <!--PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.10" /-->

--- a/osafw-app/wwwroot/assets/css/site.css
+++ b/osafw-app/wwwroot/assets/css/site.css
@@ -605,10 +605,4 @@ a.thumbnail:hover {
     background-color: #f9f9f9 !important;
     -webkit-print-color-adjust: exact !important;
   }
-
-  /* https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2135 */
-  .wk-img-transparency-fix {
-    z-index: 100;
-    position: relative;
-  }
 }


### PR DESCRIPTION
This pull request refactors the PDF generation functionality, replacing the external `wkhtmltopdf` process with the `Microsoft.Playwright` library. This change aims to modernize the PDF conversion, improve reliability, and simplify dependency management.

**Key Changes:**

* **`ConvUtils.cs`:**
    * The `html2pdf` method has been completely rewritten.
    * It now accepts HTML string data directly (`html_data`) instead of a file path.
    * It leverages Playwright to launch a headless Chromium instance, set the HTML content on a page, and then generate a PDF using `page.PdfAsync()`.
    * The method is now `async Task`, and calls to it are updated with `.GetAwaiter().GetResult()` for synchronous execution in the existing flow.
    * Removed the creation and cleanup of temporary HTML files previously needed for `wkhtmltopdf`.
    * PDF generation options (like landscape, margins, scale, etc.) are now configured through Playwright's `PagePdfOptions`.
* **`Program.cs`:**
    * Added code to the `Main` method to automatically install/update Playwright's Chromium browser (with dependencies) on application startup. This ensures the correct browser version is available for Playwright.
* **`osafw-app.csproj`:**
    * Added a `PackageReference` for `Microsoft.Playwright`.
* **`appsettings.json`:**
    * Removed the `pdf_converter` and `pdf_converter_args` settings, as these were specific to `wkhtmltopdf`.
* **`App_Data/template/dev/manage/docs/tab_installation.md`:**
    * Updated installation documentation to remove instructions for installing `wkhtmltopdf`.
* **`wwwroot/assets/css/site.css`:**
    * Removed the `.wk-img-transparency-fix` CSS rule, which was a workaround for a `wkhtmltopdf`-specific rendering issue.

**Reason for Change:**

* **Modernization & Maintainability:** Playwright is a modern, actively maintained library for browser automation and provides robust HTML-to-PDF conversion capabilities.
* **Dependency Management:** Simplifies server setup by removing the need to manually install and configure `wkhtmltopdf`. Playwright manages its browser dependency automatically.
* **Consistency & Features:** Chromium's rendering engine is expected to provide consistent PDF output and offers a rich set of features for PDF generation that can be leveraged through Playwright.
* **Eliminate External Process:** Removes the overhead and potential points of failure associated with invoking an external command-line tool.

**Impact:**

* PDF generation will now use Playwright's embedded Chromium.
* On first application run (or after Playwright library updates), the necessary Chromium browser will be downloaded and installed automatically.
* Configuration for PDF conversion via `appsettings.json` is no longer needed.
* Developers no longer need to install `wkhtmltopdf` separately.