### PR TITLE
Decouple DB from FW

### DIFF
--- a/osafw-app/App_Code/controllers/AdminDB.cs
+++ b/osafw-app/App_Code/controllers/AdminDB.cs
@@ -33,7 +33,7 @@ public class AdminDBController : FwController
             if (selected_db.Length > 0)
             {
                 logger("CONNECT TO", selected_db);
-                db = new DB(fw, (Hashtable)((Hashtable)fw.config("db"))[selected_db], selected_db);
+                db = fw.getDB(selected_db);
             }
 
             if (fw.SessionBool("admindb_pwd_checked") || reqs("pwd") == dbpwd)

--- a/osafw-app/App_Code/controllers/DevConfigure.cs
+++ b/osafw-app/App_Code/controllers/DevConfigure.cs
@@ -53,7 +53,7 @@ public class DevConfigureController : FwController
         {
             try
             {
-                db = new DB(fw);
+                db = fw.getDB();
                 db.connect();
                 ps["is_db_conn"] = true;
 

--- a/osafw-app/App_Code/controllers/DevManage.cs
+++ b/osafw-app/App_Code/controllers/DevManage.cs
@@ -329,7 +329,7 @@ public class DevManageController : FwController
         // Try
         var db = new DB(connstr, dbtype, "main");
         db.setLogger(fw.logger);
-        db.setCache(fw.context.Items);
+        db.setContext(fw.context);
 
         var entities = DevEntityBuilder.dbschema2entities(db);
 

--- a/osafw-app/App_Code/controllers/DevManage.cs
+++ b/osafw-app/App_Code/controllers/DevManage.cs
@@ -327,7 +327,9 @@ public class DevManageController : FwController
             dbtype = "OLE";
 
         // Try
-        var db = new DB(fw, new Hashtable() { { "connection_string", connstr }, { "type", dbtype } });
+        var db = new DB(connstr, dbtype, "main");
+        db.setLogger(fw.logger);
+        db.setCache(fw.context.Items);
 
         var entities = DevEntityBuilder.dbschema2entities(db);
 

--- a/osafw-app/App_Code/fw/FW.cs
+++ b/osafw-app/App_Code/fw/FW.cs
@@ -154,6 +154,18 @@ public class FW : IDisposable
         get { return userId > 0; }
     }
 
+    // helper to initialize DB instance based on configuration name
+    public DB getDB(string config_name = "main")
+    {
+        Hashtable dbconfig = (Hashtable)config("db");
+        Hashtable conf = (Hashtable)dbconfig[config_name];
+        var db = new DB(conf, config_name);
+        db.setLogger(this.logger);
+        if (context != null)
+            db.setCache(context.Items);
+        return db;
+    }
+
     // begin processing one request
     public static void run(HttpContext context, IConfiguration configuration)
     {
@@ -203,7 +215,7 @@ public class FW : IDisposable
         });
 #endif
 
-        db = new DB(this);
+        db = getDB();
         DB.SQL_QUERY_CTR = 0; // reset query counter
 
         G = (Hashtable)config().Clone(); // by default G contains conf

--- a/osafw-app/App_Code/fw/FW.cs
+++ b/osafw-app/App_Code/fw/FW.cs
@@ -159,10 +159,12 @@ public class FW : IDisposable
     {
         Hashtable dbconfig = (Hashtable)config("db");
         Hashtable conf = (Hashtable)dbconfig[config_name];
+
         var db = new DB(conf, config_name);
         db.setLogger(this.logger);
         if (context != null)
-            db.setCache(context.Items);
+            db.setContext(context);
+
         return db;
     }
 

--- a/osafw-app/App_Code/fw/FwModel.cs
+++ b/osafw-app/App_Code/fw/FwModel.cs
@@ -74,9 +74,7 @@ public abstract class FwModel : IDisposable
         this.fw = fw;
         if (!string.IsNullOrEmpty(this.db_config))
         {
-            Hashtable dbconfig = (Hashtable)fw.config("db");
-            Hashtable config_details = (Hashtable)dbconfig[this.db_config];
-            this.db = new DB(fw, config_details, this.db_config);
+            this.db = fw.getDB(this.db_config);
         }
         else
             this.db = fw.db;

--- a/osafw-app/App_Code/fw/Utils.cs
+++ b/osafw-app/App_Code/fw/Utils.cs
@@ -501,7 +501,8 @@ public class Utils
         Hashtable conf = [];
         conf["type"] = "OLE";
         conf["connection_string"] = "Provider=" + OLEDB_PROVIDER + ";Data Source=" + filepath + ";Extended Properties=\"Excel 12.0 Xml;HDR=" + (is_header ? "Yes" : "No") + ";ReadOnly=True;IMEX=1\"";
-        DB accdb = new(fw, conf);
+
+        DB accdb = new(conf);
         OleDbConnection conn = (OleDbConnection)accdb.connect();
         var schema = conn.GetOleDbSchemaTable(OleDbSchemaGuid.Tables, null);
 

--- a/osafw-app/App_Code/models/Dev/CodeGen.cs
+++ b/osafw-app/App_Code/models/Dev/CodeGen.cs
@@ -651,9 +651,9 @@ class DevCodeGen
             // TODO deprecate reading from db, always use entity info
             DB db;
             if (entity["db_config"].toStr().Length > 0)
-                db = new DB(fw, (Hashtable)((Hashtable)fw.config("db"))[entity["db_config"]], (string)entity["db_config"]);
+                db = fw.getDB((string)entity["db_config"]);
             else
-                db = new DB(fw);
+                db = fw.db;
             fields = db.loadTableSchemaFull(table_name);
             entity["foreign_keys"] = db.listForeignKeys(table_name);
 

--- a/osafw-app/App_Code/models/Dev/EntityBuilder.cs
+++ b/osafw-app/App_Code/models/Dev/EntityBuilder.cs
@@ -19,7 +19,7 @@ class DevEntityBuilder
 
     public static void createDBJsonFromExistingDB(string dbname, FW fw)
     {
-        var db = new DB(fw, (Hashtable)((Hashtable)fw.config("db"))[dbname], dbname);
+        var db = fw.getDB(dbname);
 
         var entities = DevEntityBuilder.dbschema2entities(db);
 

--- a/osafw-app/osafw-app.csproj
+++ b/osafw-app/osafw-app.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Markdig" Version="0.38.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <!--PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.10" /-->
     <!-- uncomment if use MySQL -->
     <!--PackageReference Include="MySqlConnector" Version="2.3.7" />


### PR DESCRIPTION
## Summary
- allow `DB` class to accept external logger and cache
- add `FW.getDB()` helper to provide configured `DB`
- update controllers and models to use `FW.getDB`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*