### PR TITLE
Refactor FW logging to use FwLogger

### DIFF
--- a/osafw-app/App_Code/fw/FW.cs
+++ b/osafw-app/App_Code/fw/FW.cs
@@ -121,6 +121,7 @@ public class FW : IDisposable
 
     public FwCache cache = new(); // cache instance
     public DB db;
+    public FwLogger flogger = new();
 
     public HttpContext context;
     public HttpRequest request;
@@ -209,6 +210,8 @@ public class FW : IDisposable
             scope.SetTag("ProcessId", Environment.ProcessId.ToString());
         });
 #endif
+
+        flogger = new FwLogger((LogLevel)config("log_level"), (string)config("log"), (string)config("site_root"), config("log_max_size").toLong());
 
         db = getDB();
         DB.SQL_QUERY_CTR = 0; // reset query counter
@@ -820,137 +823,19 @@ public class FW : IDisposable
     {
         if (args.Length == 0)
             return;
-        _logger(LogLevel.DEBUG, ref args);
+        flogger.Log(ref args);
     }
     public void logger(LogLevel level, params object[] args)
     {
         if (args.Length == 0)
             return;
-        _logger(level, ref args);
+        flogger.Log(level, ref args);
     }
 
     // internal logger routine, just to avoid pass args by value 2 times
     public void _logger(LogLevel level, ref object[] args)
     {
-        // skip logging if requested level more than config's debug level
-        if (level > (LogLevel)this.config("log_level"))
-            return;
-
-        StringBuilder str_prefix = new(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff"));
-        str_prefix.Append(' ').Append(level.ToString()).Append(' ');
-        str_prefix.Append(Environment.ProcessId).Append(' ');
-
-        StringBuilder str_stack = new();
-        System.Diagnostics.StackTrace st = new(true);
-
-        try
-        {
-            var i = 1;
-            System.Diagnostics.StackFrame sf = st.GetFrame(i);
-            string fname = sf.GetFileName() ?? "";
-            // skip logger methods and DB internals as we want to know line where logged thing actually called from
-            while (sf.GetMethod().Name == "logger" || fname.Length >= 6 && fname[^6..] == $@"{path_separator}DB.vb")
-            {
-                i += 1;
-                sf = st.GetFrame(i);
-            }
-            fname = sf.GetFileName();
-            if (fname != null)
-                str_stack.Append(fname.Replace((string)this.config("site_root"), "").Replace($@"{path_separator}App_Code", ""));
-            str_stack.Append(':').Append(sf.GetMethod().Name).Append(' ').Append(sf.GetFileLineNumber()).Append(" # ");
-        }
-        catch (Exception ex)
-        {
-            str_stack.Append(" ... #" + ex.Message);
-        }
-
-        StringBuilder str = new();
-        foreach (object dmp_obj in args)
-            str.Append(dumper(dmp_obj));
-
-        var strlog = str_prefix + str_stack.ToString() + str.ToString();
-
-        // write to debug console first
-        System.Diagnostics.Debug.WriteLine(strlog);
-
-        // write to log file
-        string log_file = (string)config("log");
-        if (!string.IsNullOrEmpty(log_file))
-        {
-            try
-            {
-                // force seek to end just in case other process added to file
-                using (StreamWriter floggerSW = File.AppendText(log_file))
-                {
-                    floggerSW.WriteLine(strlog);
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine("WARN logger can't write to log file. Reason:" + ex.Message);
-            }
-        }
-#if isSentry
-        // send to Sentry
-        try
-        {
-            var sentry_str = str.ToString();
-
-            //convert LogLevel to Sentry.SentryLevel and Sentry.BreadcrumbLevel
-            Sentry.SentryLevel sentryLevel = Sentry.SentryLevel.Error;
-            Sentry.BreadcrumbLevel breadcrumbLevel = Sentry.BreadcrumbLevel.Error;
-
-            if (level == LogLevel.FATAL)
-            {
-                sentryLevel = Sentry.SentryLevel.Fatal;
-                breadcrumbLevel = Sentry.BreadcrumbLevel.Critical;
-            }
-            else if (level == LogLevel.ERROR)
-            {
-                sentryLevel = Sentry.SentryLevel.Error;
-                breadcrumbLevel = Sentry.BreadcrumbLevel.Error;
-            }
-            else if (level == LogLevel.WARN)
-            {
-                sentryLevel = Sentry.SentryLevel.Warning;
-                breadcrumbLevel = Sentry.BreadcrumbLevel.Warning;
-            }
-            else
-            {
-                sentryLevel = Sentry.SentryLevel.Info;
-                breadcrumbLevel = Sentry.BreadcrumbLevel.Info;
-            }
-
-            //log to Sentry as separate events only WARN, ERROR, FATAL
-            if (level <= LogLevel.WARN)
-            {
-
-                if (args.Length > 0 && args[0] is Exception ex)
-                {
-                    //if first argument is an exception - send it as exception with strlog as an additional info
-                    Sentry.SentrySdk.CaptureException(ex, scope =>
-                        {
-                            scope.Level = sentryLevel;
-                            scope.SetExtra("message", sentry_str);
-                        });
-                }
-                else
-                    Sentry.SentrySdk.CaptureMessage(sentry_str, sentryLevel);
-
-                //also add as a breadcrumb for the future events
-                Sentry.SentrySdk.AddBreadcrumb(str_stack.ToString() + sentry_str, null, null, null, breadcrumbLevel);
-            }
-            else
-            {
-                //log to Sentry as breadcrumbs only
-                Sentry.SentrySdk.AddBreadcrumb(str_stack.ToString() + sentry_str, null, null, null, breadcrumbLevel);
-            }
-        }
-        catch (Exception)
-        {
-            // make sure we don't break the app if Sentry fails
-        }
-#endif
+        flogger.Log(level, ref args);
     }
 
     public static string dumper(object dmp_obj, int level = 0) // TODO better type detection(suitable for all collection types)
@@ -1881,33 +1766,11 @@ public class FW : IDisposable
             {
                 // dispose managed state (managed objects).
                 db.Dispose(); // this will return db connections to pool
+                flogger.Dispose();
             }
 
             // free unmanaged resources (unmanaged objects) and override Finalize() below.
-            try
-            {
-                // check if log file too large and need to be rotated
-                string log_file = (string)config("log");
-                if (!string.IsNullOrEmpty(log_file))
-                {
-                    long max_log_size = config("log_max_size").toLong();
-                    using (FileStream floggerFS = new(log_file, FileMode.Open, FileAccess.Read, FileShare.Read))
-                    {
-                        if (max_log_size > 0 && floggerFS.Length > max_log_size)
-                        {
-                            floggerFS.Close();
-                            var to_path = log_file + ".1";
-                            File.Delete(to_path);
-                            File.Move(log_file, to_path);
-                        }
-                    }
-                }
-            }
             // TODO: set large fields to null.
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine("exception in Dispose:" + ex.Message);
-            }
         }
         disposedValue = true;
     }

--- a/osafw-app/App_Code/fw/FwLogger.cs
+++ b/osafw-app/App_Code/fw/FwLogger.cs
@@ -1,5 +1,3 @@
-﻿// TODO rework logger into this separate class properly
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -7,98 +5,192 @@ using System.Text;
 
 namespace osafw;
 
-public class FwLogger
+public class FwLogger : IDisposable
 {
     public LogLevel log_level;
-    public string log_file;
-    public string site_root;
+    public string log_file = "";
+    public string site_root = "";
+    public long log_max_size = 0;
 
-    private System.IO.FileStream floggerFS;
-    private System.IO.StreamWriter floggerSW;
+    private FileStream? floggerFS;
+    private StreamWriter? floggerSW;
 
-    //TODO constructor setting log_level, site_root, log_file
-    // this.log_level = (LogLevel)Enum.Parse(typeof(LogLevel), log_level)
-    /*
-     *<summary>
-     * Logger levels, ex: logger(LogLevel.ERROR, "Something happened")
-     * </summary>
-     */
-    public enum LogLevel : int {
-        OFF = 0,             // no logging occurs
-        FATAL = 1,           // severe error, current request (or even whole application) aborted (notify admin)
-        ERROR = 2,           // error happened, but current request might still continue (notify admin)
-        WARN = 3,            // potentially harmful situations for further investigation, request processing continues
-        INFO = 4,            // default for production (easier maintenance/support), progress of the application at coarse-grained level (fw request processing: request start/end, sql, route/external redirects, sql, fileaccess, third-party API)
-        DEBUG = 5,           // default for development (default for logger("msg") call), fine-grained level
-        TRACE = 6,           // very detailed dumps (in-module details like fw core, despatcher, parse page, ...)
-        ALL = 7              // just log everything
+    public FwLogger() { }
+
+    public FwLogger(LogLevel log_level, string log_file, string site_root, long log_max_size = 0)
+    {
+        this.log_level = log_level;
+        this.log_file = log_file;
+        this.site_root = site_root;
+        this.log_max_size = log_max_size;
     }
-    // internal logger routine, just to avoid pass args by value 2 times
-    public void logger(LogLevel level, ref Object[] args) {
-        // skip logging if requested level more than config's debug level
+
+    public void Log(params object[] args)
+    {
+        if (args.Length == 0) return;
+        Log(LogLevel.DEBUG, ref args);
+    }
+
+    public void Log(LogLevel level, params object[] args)
+    {
+        if (args.Length == 0) return;
+        Log(level, ref args);
+    }
+
+    public void Log(LogLevel level, ref object[] args)
+    {
         if (level > log_level) return;
 
-        StringBuilder str = new(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff"));
-        str.Append(" ").Append(level.ToString()).Append(" ");
-        str.Append(System.Diagnostics.Process.GetCurrentProcess().Id).Append(" ");
+        StringBuilder str_prefix = new(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff"));
+        str_prefix.Append(' ').Append(level.ToString()).Append(' ');
+        str_prefix.Append(Environment.ProcessId).Append(' ');
+
+        StringBuilder str_stack = new();
         StackTrace st = new(true);
 
         try
         {
             int i = 1;
             StackFrame sf = st.GetFrame(i);
-            // skip logger methods and DB internals as we want to know line where logged thing actually called from
-            String fname = sf.GetFileName();
-            String method_name = sf.GetMethod().Name;
-            while (method_name == "logger" || fname.EndsWith("\\DB.vb")) {
+            string fname = sf.GetFileName() ?? "";
+            while (sf.GetMethod().Name == "logger" || fname.EndsWith(Path.DirectorySeparatorChar + "DB.vb"))
+            {
                 i += 1;
                 sf = st.GetFrame(i);
-                method_name = sf.GetMethod().Name;
-                fname = sf.GetFileName();
+                fname = sf.GetFileName() ?? "";
             }
             fname = sf.GetFileName();
-            if (fname != null) { // nothing in Release configuration
-                fname = fname.Replace(this.site_root, "");
-                fname = fname.Replace("\\App_Code", "");
-                str.Append(fname);
-            }
-            str.Append(':').Append(method_name).Append(' ').Append(sf.GetFileLineNumber().ToString()).Append(" # ");
+            if (fname != null)
+                str_stack.Append(fname.Replace(site_root, "").Replace(Path.DirectorySeparatorChar + "App_Code", ""));
+            str_stack.Append(':').Append(sf.GetMethod().Name).Append(' ').Append(sf.GetFileLineNumber()).Append(" # ");
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            str.Append(" ... #");
+            str_stack.Append(" ... #" + ex.Message);
         }
 
-        foreach (Object dmp_obj in args)
-        {
+        StringBuilder str = new();
+        foreach (object dmp_obj in args)
             str.Append(FW.dumper(dmp_obj));
-        }
 
-        // write to debug console first
-        System.Diagnostics.Debug.WriteLine(str);
+        var strlog = str_prefix + str_stack.ToString() + str.ToString();
 
-        // write to log file
-        if (!string.IsNullOrEmpty(this.log_file))
+        Debug.WriteLine(strlog);
+
+        if (!string.IsNullOrEmpty(log_file))
         {
             try
             {
-                // keep log file open to avoid overhead
+                RotateIfNeeded();
                 if (floggerFS == null)
                 {
-                    // open log with shared read/write so loggers from other processes can still write to it
                     floggerFS = new FileStream(log_file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                    floggerSW = new (floggerFS);
+                    floggerSW = new StreamWriter(floggerFS);
                     floggerSW.AutoFlush = true;
                 }
-                // force seek to end just in case other process added to file
                 floggerFS.Seek(0, SeekOrigin.End);
-                floggerSW.WriteLine(str.ToString());
+                floggerSW.WriteLine(strlog);
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine("WARN logger can't write to log file. Reason:" + ex.Message);
+                Debug.WriteLine("WARN logger can't write to log file. Reason:" + ex.Message);
             }
         }
+#if isSentry
+        try
+        {
+            var sentry_str = str.ToString();
 
+            Sentry.SentryLevel sentryLevel = Sentry.SentryLevel.Error;
+            Sentry.BreadcrumbLevel breadcrumbLevel = Sentry.BreadcrumbLevel.Error;
+
+            if (level == LogLevel.FATAL)
+            {
+                sentryLevel = Sentry.SentryLevel.Fatal;
+                breadcrumbLevel = Sentry.BreadcrumbLevel.Critical;
+            }
+            else if (level == LogLevel.ERROR)
+            {
+                sentryLevel = Sentry.SentryLevel.Error;
+                breadcrumbLevel = Sentry.BreadcrumbLevel.Error;
+            }
+            else if (level == LogLevel.WARN)
+            {
+                sentryLevel = Sentry.SentryLevel.Warning;
+                breadcrumbLevel = Sentry.BreadcrumbLevel.Warning;
+            }
+            else
+            {
+                sentryLevel = Sentry.SentryLevel.Info;
+                breadcrumbLevel = Sentry.BreadcrumbLevel.Info;
+            }
+
+            if (level <= LogLevel.WARN)
+            {
+                if (args.Length > 0 && args[0] is Exception ex)
+                {
+                    Sentry.SentrySdk.CaptureException(ex, scope =>
+                    {
+                        scope.Level = sentryLevel;
+                        scope.SetExtra("message", sentry_str);
+                    });
+                }
+                else
+                    Sentry.SentrySdk.CaptureMessage(sentry_str, sentryLevel);
+
+                Sentry.SentrySdk.AddBreadcrumb(str_stack.ToString() + sentry_str, null, null, null, breadcrumbLevel);
+            }
+            else
+            {
+                Sentry.SentrySdk.AddBreadcrumb(str_stack.ToString() + sentry_str, null, null, null, breadcrumbLevel);
+            }
+        }
+        catch (Exception)
+        {
+        }
+#endif
+    }
+
+    private void RotateIfNeeded()
+    {
+        if (log_max_size <= 0 || string.IsNullOrEmpty(log_file)) return;
+
+        try
+        {
+            if (floggerFS != null)
+                floggerFS.Flush();
+
+            FileInfo fi = new FileInfo(log_file);
+            if (!fi.Exists) return;
+            if (fi.Length <= log_max_size) return;
+
+            floggerSW?.Dispose();
+            floggerFS?.Dispose();
+            floggerSW = null;
+            floggerFS = null;
+
+            string to_path = log_file + ".1";
+            File.Delete(to_path);
+            File.Move(log_file, to_path);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine("WARN logger can't rotate log file. Reason:" + ex.Message);
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            RotateIfNeeded();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine("exception in FwLogger.Dispose:" + ex.Message);
+        }
+
+        floggerSW?.Dispose();
+        floggerFS?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- centralize logging logic into `FwLogger`
- delegate FW logging methods to the new logger
- initialize logger from configuration and dispose with FW

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*