### PR TITLE
Add preliminary Passkey login support

### DIFF
--- a/osafw-app/App_Code/models/Users.cs
+++ b/osafw-app/App_Code/models/Users.cs
@@ -81,14 +81,14 @@ public class Users : FwModel
 
     public DBRow oneByPasskey(string credentialId)
     {
-        return db.row(table_name, DB.h("passkey_id", credentialId));
+        return db.row(table_name, DB.h("passkey", credentialId));
     }
 
     public void savePasskey(int id, string credentialId, string publicKey)
     {
         var item = new Hashtable
         {
-            {"passkey_id", credentialId},
+            {"passkey", credentialId},
             {"passkey_pub", publicKey}
         };
         update(id, item);

--- a/osafw-app/App_Data/sql/fwdatabase.sql
+++ b/osafw-app/App_Data/sql/fwdatabase.sql
@@ -238,6 +238,10 @@ CREATE TABLE users (
   mfa_added             DATETIME2,    -- last datetime when mfa setup or resynced
   login                 NVARCHAR(128) NULL, -- windows authentication login
 
+  -- PassKeys support
+  passkey               NVARCHAR(255) NOT NULL DEFAULT '', -- passkey credential id
+  passkey_pub           NVARCHAR(MAX) NOT NULL DEFAULT '', -- public key
+
   status                TINYINT NOT NULL DEFAULT 0,        /*0-ok, 127-deleted*/
   add_time              DATETIME2 NOT NULL DEFAULT getdate(),
   add_users_id          INT DEFAULT 0,

--- a/osafw-app/App_Data/sql/updates/upd2025-05-28.sql
+++ b/osafw-app/App_Data/sql/updates/upd2025-05-28.sql
@@ -1,0 +1,4 @@
+-- PassKey support
+ALTER TABLE users ADD passkey NVARCHAR(255);
+ALTER TABLE users ADD passkey_pub NVARCHAR(MAX);
+

--- a/osafw-app/App_Data/sql/updates/upd2025-08-01.sql
+++ b/osafw-app/App_Data/sql/updates/upd2025-08-01.sql
@@ -1,3 +1,0 @@
-ALTER TABLE users ADD passkey_id NVARCHAR(255);
-ALTER TABLE users ADD passkey_pub NVARCHAR(MAX);
-GO

--- a/osafw-app/App_Data/template/login/index/form.html
+++ b/osafw-app/App_Data/template/login/index/form.html
@@ -8,11 +8,6 @@
         or sign in with email
       </p>
   </~btn_google>
-  <div class="d-grid mb-3" id="passkey-login-container" style="display:none">
-    <button type="button" class="btn btn-lg btn-success w-100" id="passkey-login-btn">
-      <i class="bi bi-key"></i> `Sign in with Passkey`
-    </button>
-  </div>
 
     <div class="form-floating mb-3">
       <input type="email" id="login" class="form-control form-control-lg filled" name="item[login]" value="<~i[login]>" placeholder="name@example.com" autofocus>
@@ -46,6 +41,12 @@
         <a class="btn btn-link" href="<~/signup/url>">`Sign Up`</a>
       </~btn_signup>
     </p>
+
+    <div class="d-grid mb-3" id="passkey-login-container" style="display:none">
+      <button type="button" class="btn btn-lg btn-success w-100" id="passkey-login-btn" data-url="<~/login/url>">
+        <i class="bi bi-key"></i> `Sign in with Passkey`
+      </button>
+    </div>
 
     <!--div class="d-grid">
       <a class="btn btn-lg btn-success w-100" href="<~ROOT_URL>/WinLogin" role="button">`Windows Login`</a>

--- a/osafw-app/App_Data/template/login/index/onload.js
+++ b/osafw-app/App_Data/template/login/index/onload.js
@@ -3,7 +3,9 @@ pwd_hideshow();
 if (window.PublicKeyCredential) {
   $('#passkey-login-container').show();
 }
-$(document).on('click', '#passkey-login-btn', startPasskeyLogin);
+$(document).on('click', '#passkey-login-btn', function (e) {
+  startPasskeyLogin($(this).data(url));
+});
 
 $('#login').focus();
 
@@ -22,10 +24,11 @@ function pwd_hideshow(){
   }
 }
 
-function startPasskeyLogin(){
-  $.getJSON('<~/login/url>/(PasskeyStart)', function(options){
+function startPasskeyLogin(login_url){
+  $.getJSON(login_url+'/(PasskeyStart)', function(options){
     options.publicKey.challenge = Uint8Array.from(atob(options.publicKey.challenge), c=>c.charCodeAt(0));
-    options.publicKey.allowCredentials.forEach(function(c){ c.id = Uint8Array.from(atob(c.id), ch=>ch.charCodeAt(0)); });
+    options.publicKey.allowCredentials.forEach(function (c) { c.id = Uint8Array.from(atob(c.id), ch => ch.charCodeAt(0)); });
+
     navigator.credentials.get({publicKey: options.publicKey}).then(function(cred){
       const authData={
         id: cred.id,
@@ -38,9 +41,10 @@ function startPasskeyLogin(){
           userHandle: cred.response.userHandle?btoa(String.fromCharCode.apply(null,new Uint8Array(cred.response.userHandle))):null
         }
       };
-      $.ajax({url:'<~/login/url>/(PasskeyLogin)',method:'POST',contentType:'application/json',data:JSON.stringify(authData)})
-        .done(function(){window.location='<~/login/url>';})
-        .fail(function(){alert('Passkey login failed');});
-    }).catch(function(){alert('Passkey login cancelled');});
+
+      $.ajax({ url: login_url + '/(PasskeyLogin)',method:'POST',contentType:'application/json',data:JSON.stringify(authData)})
+        .done(function () { window.location = '/';})
+        .fail(function(){fw.error('Passkey login failed');});
+    }).catch(function(){fw.error('Passkey login cancelled');});
   });
 }

--- a/osafw-app/osafw-app.csproj
+++ b/osafw-app/osafw-app.csproj
@@ -9,8 +9,9 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.0.5" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="Fido2" Version="3.0.1" />
     <PackageReference Include="Markdig" Version="0.41.1" />
-	<PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+	  <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="9.0.5" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.52.1" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
@@ -20,7 +21,6 @@
     <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.5" />
     <PackageReference Include="Cronos" Version="0.11.0" />
-    <PackageReference Include="Fido2NetLib" Version="3.3.0" />
     
     <!-- uncomment if use Windows authentication -->
     <!--PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.10" /-->


### PR DESCRIPTION
## Summary
- add optional Passkey login support via WebAuthn
- UI updates for Passkey button and JS logic
- controller logic for Passkey start and login
- model helpers for Passkey data
- schema update for storing passkey info

## Testing
- `dotnet build osafw-asp.net-core.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*
- `dotnet test osafw-asp.net-core.sln` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*