### PR TITLE
Add quick report generator to DevManage

### DIFF
--- a/osafw-app/App_Code/controllers/DevManage.cs
+++ b/osafw-app/App_Code/controllers/DevManage.cs
@@ -284,6 +284,17 @@ public class DevManageController : FwController
         fw.redirect(base_url);
     }
 
+    public void CreateReportAction()
+    {
+        var item = reqh("item");
+        var repcode = item["report_code"].toStr().Trim();
+
+        DevCodeGen.init(fw).createReport(repcode);
+
+        fw.flash("success", repcode + " report created");
+        fw.redirect(base_url);
+    }
+
     public void ExtractControllerAction()
     {
         var item = reqh("item");

--- a/osafw-app/App_Code/models/Dev/CodeGen.cs
+++ b/osafw-app/App_Code/models/Dev/CodeGen.cs
@@ -711,7 +711,8 @@ class DevCodeGen
 
         List<Hashtable> formTabs = [
             //default
-            new Hashtable {
+            new Hashtable
+            {
                 ["tab"] = "",
                 ["label"] = "Main"
             }
@@ -1430,6 +1431,35 @@ class DevCodeGen
                     }
             }
         }
+    }
+
+    public void createReport(string repcode)
+    {
+        repcode = FwReports.cleanupRepcode(repcode);
+        if (string.IsNullOrEmpty(repcode))
+            throw new UserException("No report code");
+
+        var report_class = FwReports.repcodeToClass(repcode);
+        var reports_path = fw.config("site_root") + @"\App_Code\models\Reports";
+        var src_file = reports_path + @"\Sample.cs";
+        var dest_file = reports_path + @"\" + report_class.Replace("Report", "") + ".cs";
+
+        if (File.Exists(dest_file))
+            throw new UserException("Such report already exists");
+
+        var content = Utils.getFileContent(src_file);
+        if (content == "")
+            throw new ApplicationException("Can't open Sample.cs");
+
+        content = content.Replace("SampleReport", report_class);
+        content = content.Replace("Sample report", Utils.capitalize(repcode) + " report");
+
+        Utils.setFileContent(dest_file, ref content);
+
+        // copy templates
+        var tpl_from = fw.config("template") + "/admin/reports/sample";
+        var tpl_to = fw.config("template") + "/admin/reports/" + repcode.ToLower();
+        Utils.CopyDirectory(tpl_from, tpl_to, true);
     }
     // update by url
     private void updateMenuItem(string controller_url, string controller_title)

--- a/osafw-app/App_Data/template/dev/manage/index/main.html
+++ b/osafw-app/App_Data/template/dev/manage/index/main.html
@@ -125,4 +125,15 @@ existing DB &rarr; db.json &rarr; models &rarr; controllers
             </div>
         </form>
     </li>
+    <li class="mt-2">
+        <form method="post" action="<~../url>/(CreateReport)" class="row row-cols-auto g-2">
+            <input type="hidden" name="XSS" value="<~session[XSS]>">
+            <div class="col">
+                <input name="item[report_code]" maxlength="255" value="<~i[report_code]>" type="text" class="form-control ms-2" placeholder="Report code" style="width:200px">
+            </div>
+            <div class="col">
+                <button class="btn btn-default ms-2">Create Report</button>
+            </div>
+        </form>
+    </li>
 </ul>


### PR DESCRIPTION
## Summary
- allow creating new report classes quickly
- implement `createReport` in `DevCodeGen`
- wire up `CreateReportAction` in `DevManageController`
- add report form to developer tools

## Testing
- `dotnet build --no-restore` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_683deee5f8488322acf4184bb64ab0ad