### PR TITLE
Add DI registration for core services

### DIFF
--- a/osafw-app/App_Code/fw/ServiceCollectionExtensions.cs
+++ b/osafw-app/App_Code/fw/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections;
+
+namespace osafw;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddFwServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        var settings = FwConfig.settingsForEnvironment(configuration);
+        var dbSection = (Hashtable)settings["db"];
+        var main = (Hashtable)dbSection["main"];
+        var connStr = (string)main["connection_string"];
+        var dbType = (string)main["type"];
+
+        services.AddScoped<DB>(_ => new DB(connStr, dbType, "main"));
+        services.AddScoped<FwCache>();
+        services.AddLogging();
+        return services;
+    }
+}

--- a/osafw-app/Program.cs
+++ b/osafw-app/Program.cs
@@ -141,14 +141,19 @@ public static class Program
         // Windows Active Directory authentication support (optional)
         // builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme).AddNegotiate();
 
-        // Memory cache 
+        // Memory cache
         builder.Services.AddMemoryCache();
+
+        // register FW core services
+        builder.Services.AddFwServices(builder.Configuration);
 
         // Uncomment to enable scheduled tasks
         // builder.Services.AddHostedService<FwCronService>();
 
         // Build the WebApplication
         var app = builder.Build();
+
+        FW.service_provider = app.Services;
 
         //-------------------------------
         // Configure the middleware pipeline

--- a/osafw-tests/App_Code/fw/DBTests.cs
+++ b/osafw-tests/App_Code/fw/DBTests.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace osafw.Tests
 {
@@ -11,13 +12,17 @@ namespace osafw.Tests
     public class DBTests
     {
         private readonly string connstr = "Server=(local);Database=demo;Trusted_Connection=True;TrustServerCertificate=true;";
+        private ServiceProvider provider = null;
         private DB db = null;
         private string table_name = "for_unit_testing";
 
         [TestInitialize()]
         public void Startup()
         {
-            db = new DB(connstr, "SQL", "main");
+            var services = new ServiceCollection();
+            services.AddScoped<DB>(_ => new DB(connstr, "SQL", "main"));
+            provider = services.BuildServiceProvider();
+            db = provider.GetRequiredService<DB>();
             db.connect();
             // create tables for testing
             db.exec($"DROP TABLE IF EXISTS {table_name}");
@@ -34,6 +39,7 @@ namespace osafw.Tests
         {
             db.exec($"DROP TABLE {table_name}");
             db.disconnect();
+            provider.Dispose();
         }
 
         [TestMethod()]

--- a/osafw-tests/App_Code/fw/FwCacheTests.cs
+++ b/osafw-tests/App_Code/fw/FwCacheTests.cs
@@ -1,11 +1,29 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace osafw.Tests
 {
     [TestClass()]
     public class FwCacheTests
     {
+        private ServiceProvider provider;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddMemoryCache();
+            provider = services.BuildServiceProvider();
+            FwCache.MemoryCache = provider.GetRequiredService<IMemoryCache>();
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            provider.Dispose();
+        }
         [TestMethod()]
         public void getValueTest()
         {


### PR DESCRIPTION
## Summary
- provide `AddFwServices` extension to register DB, FwCache and logging
- expose `FW.service_provider` and resolve DB/FwCache from DI
- register FW services in Program.cs
- update tests to resolve dependencies from a ServiceProvider

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_682e46e593288322ab36d206b02db5d3