### PR TITLE
Refactor list index toolbar into single row

### DIFF
--- a/osafw-app/App_Data/template/admin/att/index/list_filter_more.html
+++ b/osafw-app/App_Data/template/admin/att/index/list_filter_more.html
@@ -1,11 +1,11 @@
-<div class="row form-row">
-  <label class="col-form-label col-md-2 col-xl-1" for="fatt_categories_id">`Category`</label>
-  <div class="col-sm-4 col-md-3">
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Category`</span>
     <select id="fatt_categories_id" name="f[att_categories_id]" class="form-select">
       <option value="">- all -</option>
       <~select_att_categories_ids select="f[att_categories_id]">
     </select>
   </div>
-
-  <~/common/list/fstatus>
 </div>
+
+<~/common/list/fstatus>

--- a/osafw-app/App_Data/template/admin/demodicts/index/main.html
+++ b/osafw-app/App_Data/template/admin/demodicts/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/admin/demos/index/main.html
+++ b/osafw-app/App_Data/template/admin/demos/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/admin/demosdynamic/index/main.html
+++ b/osafw-app/App_Data/template/admin/demosdynamic/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/admin/roles/index/main.html
+++ b/osafw-app/App_Data/template/admin/roles/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/admin/spages/index/main.html
+++ b/osafw-app/App_Data/template/admin/spages/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/admin/users/index/list_filter_more.html
+++ b/osafw-app/App_Data/template/admin/users/index/list_filter_more.html
@@ -1,21 +1,23 @@
 <input type="hidden" name="f[is_search]" value="<~f[is_search]>">
-<div class="row form-row">
-  <label class="col-form-label col-md-2 col-xl-1" for="fstatus">`Status`</label>
-  <div class="col-md-3 col-lg-2">
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Status`</span>
     <select id="fstatus" name="f[status]" class="form-select">
       <option value="">`- all -`</option>
       <~../statusf.sel select="f[status]" iflt="SESSION[access_level]" value="100">
       <~../status.sel select="f[status]" ifeq="SESSION[access_level]" value="100">
     </select>
   </div>
+</div>
 
-  <label class="col-form-label col-md-2 col-xl-1" for="faccess_level">`Access Level`</label>
-  <div class="col-md-3 col-lg-2">
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Access Level`</span>
     <select id="faccess_level" name="f[access_level]" class="form-select">
       <option value="">`- all -`</option>
       <~/common/sel/access_level.sel select="f[access_level]">
     </select>
   </div>
-
-  <~/common/list/fexport>
 </div>
+
+<~/common/list/fexport>

--- a/osafw-app/App_Data/template/admin/users/index/main.html
+++ b/osafw-app/App_Data/template/admin/users/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/common/list/fexport.html
+++ b/osafw-app/App_Data/template/common/list/fexport.html
@@ -1,4 +1,4 @@
-  <div class="col text-end d-print-none">
+  <div class="col-auto ms-auto d-print-none">
     <div class="btn-group">
       <button type="submit" name="export" value="csv" class="btn btn-outline-secondary"><i class="bi bi-cloud-download"></i> `Export`</button>
       <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/osafw-app/App_Data/template/common/list/filter_std.html
+++ b/osafw-app/App_Data/template/common/list/filter_std.html
@@ -6,7 +6,21 @@
   <~/common/form/relid>
   <~list_filter_inputs>
 
-  <~/common/list/filter_search>
-  
-  <~list_filter_more>
+  <div class="row g-2 align-items-center d-print-none">
+    <div class="col-auto">
+      <div class="btn-group">
+        <a class="btn btn-default" href="<~../url>/new<~/common/list/relidq>" <~/common/disabled if="is_readonly">><i class="bi bi-plus-lg"></i> `Add New`</a>
+        <~btn_std_more>
+      </div>
+    </div>
+
+    <~/common/list/fsearch>
+    <~list_filter_more>
+  </div>
+
+  <~more_rows if="list_filter_more_rows" inline>
+    <div class="row g-2 align-items-center d-print-none">
+      <~list_filter_more_rows>
+    </div>
+  </~more_rows>
 </form>

--- a/osafw-app/App_Data/template/common/list/filter_std_status.html
+++ b/osafw-app/App_Data/template/common/list/filter_std_status.html
@@ -1,3 +1,1 @@
-<div class="row form-row">
-  <~/common/list/fstatus>
-</div>
+<~/common/list/fstatus>

--- a/osafw-app/App_Data/template/common/list/filter_std_status_export.html
+++ b/osafw-app/App_Data/template/common/list/filter_std_status_export.html
@@ -1,5 +1,3 @@
-<div class="row form-row">
-  <~/common/list/fstatus>
-  <~/common/list/fuserlists if="is_userlists">
-  <~/common/list/fexport>
-</div>
+<~/common/list/fstatus>
+<~/common/list/fuserlists if="is_userlists">
+<~/common/list/fexport>

--- a/osafw-app/App_Data/template/common/list/filter_std_su.html
+++ b/osafw-app/App_Data/template/common/list/filter_std_su.html
@@ -1,4 +1,2 @@
-<div class="row form-row">
-  <~/common/list/fstatus>
-  <~/common/list/fuserlists>
-</div>
+<~/common/list/fstatus>
+<~/common/list/fuserlists>

--- a/osafw-app/App_Data/template/common/list/fsearch.html
+++ b/osafw-app/App_Data/template/common/list/fsearch.html
@@ -1,8 +1,7 @@
-  <label class="col-form-label col-md-2 col-xl-1" for="fs">`Search`</label>
   <div class="col">
       <div class="input-group">
           <input type="text" id="fs" name="f[s]" value="<~f[s]>" maxlength="255" class="form-control" placeholder="<~list_filter_search_placeholder>">
           <button class="btn btn-outline-secondary w100"><i class="bi bi-search"></i></button>
-          <a href="<~/common/list/reset_filter_relid>" class="btn btn-outline-secondary w100 on-filter-reset">`Reset`</a>
+          <a href="<~/common/list/reset_filter_relid>" class="btn btn-outline-secondary w100 on-filter-reset"><i class="bi bi-x-lg"></i></a>
       </div>
   </div>

--- a/osafw-app/App_Data/template/common/list/fstatus.html
+++ b/osafw-app/App_Data/template/common/list/fstatus.html
@@ -1,8 +1,10 @@
-  <label class="col-form-label col-md-2 col-xl-1" for="fstatus">`Status`</label>
-  <div class="col-md-3 col-lg-2">
-    <select id="fstatus" name="f[status]" class="form-select">
-      <option value="">`- all -`</option>
-      <~/common/sel/statusf.sel select="f[status]" iflt="SESSION[access_level]" value="100">
-      <~/common/sel/statusf_admin.sel select="f[status]" ifeq="SESSION[access_level]" value="100">
-    </select>
+  <div class="col-auto">
+    <div class="input-group">
+      <span class="input-group-text">`Status`</span>
+      <select id="fstatus" name="f[status]" class="form-select">
+        <option value="">`- all -`</option>
+        <~/common/sel/statusf.sel select="f[status]" iflt="SESSION[access_level]" value="100">
+        <~/common/sel/statusf_admin.sel select="f[status]" ifeq="SESSION[access_level]" value="100">
+      </select>
+    </div>
   </div>

--- a/osafw-app/App_Data/template/common/list/fuserlists.html
+++ b/osafw-app/App_Data/template/common/list/fuserlists.html
@@ -1,7 +1,9 @@
-  <label class="col-form-label col-md-2 col-xl-1" for="fuserlist">`My List`</label>
-  <div class="col-md-3 col-lg-2">
-    <select id="fuserlist" name="f[userlist]" class="form-select">
-      <option value="">`- all -`</option>
-      <~select_userlists select="f[userlist]">
-    </select>
+  <div class="col-auto">
+    <div class="input-group">
+      <span class="input-group-text">`My List`</span>
+      <select id="fuserlist" name="f[userlist]" class="form-select">
+        <option value="">`- all -`</option>
+        <~select_userlists select="f[userlist]">
+      </select>
+    </div>
   </div>

--- a/osafw-app/App_Data/template/common/list/title.html
+++ b/osafw-app/App_Data/template/common/list/title.html
@@ -1,0 +1,9 @@
+<div class="d-flex align-items-center mb-2">
+  <div class="d-flex align-items-center me-auto">
+    <~back if="return_url" inline><a class="btn btn-default me-2" href="<~return_url>"><i class="bi bi-arrow-left-circle"></i> `Return Back`</a></~back>
+    <h1 class="mb-0"><~title><~cnt if="count" inline> (<~count>)</~cnt></h1>
+  </div>
+  <div class="d-print-none">
+    <~title_buttons>
+  </div>
+</div>

--- a/osafw-app/App_Data/template/my/filters/index/main.html
+++ b/osafw-app/App_Data/template/my/filters/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title></h1>
+<~#/common/list/title>
 
-<~#/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/my/lists/index/list_filter_more.html
+++ b/osafw-app/App_Data/template/my/lists/index/list_filter_more.html
@@ -1,13 +1,15 @@
-<div class="row form-row">
-  <label class="col-form-label col-sm-2 col-md-1" for="fentity">`Screen`</label>
-  <div class="col-sm-4">
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Screen`</span>
     <select id="fentity" name="f[entity]" class="form-select">
       <option value="">- all -</option>
       <~select_entities select="f[entity]">
     </select>
   </div>
-  <label class="col-form-label col-sm-1" for="fstatus">`Status`</label>
-  <div class="col-sm-2">
+</div>
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Status`</span>
     <select id="fstatus" name="f[status]" class="form-select">
       <option value="">- all -</option>
       <~/common/sel/status.sel select="f[status]">

--- a/osafw-app/App_Data/template/my/lists/index/main.html
+++ b/osafw-app/App_Data/template/my/lists/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title> (<~count>)</h1>
+<~/common/list/title>
 
-<~/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>

--- a/osafw-app/App_Data/template/my/views/index/list_filter_more.html
+++ b/osafw-app/App_Data/template/my/views/index/list_filter_more.html
@@ -1,13 +1,15 @@
-<div class="row form-row">
-  <label class="col-form-label col-sm-2 col-md-1" for="ficode">`Screen`</label>
-  <div class="col-sm-4">
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Screen`</span>
     <select id="ficode" name="f[icode]" class="form-select">
       <option value="">- all -</option>
       <~select_icodes select="f[icode]">
     </select>
   </div>
-  <label class="col-form-label col-sm-1" for="fstatus">`Status`</label>
-  <div class="col-sm-2">
+</div>
+<div class="col-auto">
+  <div class="input-group">
+    <span class="input-group-text">`Status`</span>
     <select id="fstatus" name="f[status]" class="form-select">
       <option value="">- all -</option>
       <~/common/sel/statusf.sel select="f[status]">

--- a/osafw-app/App_Data/template/my/views/index/main.html
+++ b/osafw-app/App_Data/template/my/views/index/main.html
@@ -1,6 +1,5 @@
-<h1><~title></h1>
+<~#/common/list/title>
 
-<~#/common/list/btn_std>
 <~/common/form/msg>
 
 <~/common/list/filter_std>


### PR DESCRIPTION
## Summary
- compress list filters into a single toolbar with Add New, search, status and export options
- add reusable title header with optional back button and extra actions
- update existing admin and user list templates to adopt new compact layout

## Testing
- `dotnet build osafw-asp.net-core.sln` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*
- `dotnet test osafw-tests/osafw-tests.csproj` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b73abcd0a88322be1bab2c4f86b4c8