### PR TITLE
Add SQLite support to DB helper, init SQL scripts, and Users SQLite tests

### DIFF
--- a/docs/agents/tasks/summary-2026-01-28-sqlite-support.md
+++ b/docs/agents/tasks/summary-2026-01-28-sqlite-support.md
@@ -1,0 +1,17 @@
+## What changed
+- Added SQLite support to the DB helper, including connection handling, schema inspection, identity retrieval, and foreign key discovery.
+- Added SQLite schema/init SQL scripts under App_Data/sql/sqlite and a Users CRUD test that initializes SQLite schema.
+- Added Microsoft.Data.Sqlite package reference for SQLite connectivity.
+
+## Commands that worked (build/test/run)
+- /root/dotnet/dotnet build (failed: libman CDN resolution)
+
+## Pitfalls - fixes
+- dotnet build failed due to libman CDN resolution errors when restoring front-end libraries.
+
+## Decisions - why
+- SQLite schema scripts mirror SQL Server core tables to support local development and tests without SQL Server.
+- Users CRUD test initializes SQLite schema from App_Data/sql/sqlite to validate DB helper + model workflows.
+
+## Heuristics (keep terse)
+- Prefer SQLite PRAGMA introspection for schema and foreign key metadata.

--- a/docs/agents/tasks/summary-2026-01-28-sqlite-support.md
+++ b/docs/agents/tasks/summary-2026-01-28-sqlite-support.md
@@ -2,16 +2,19 @@
 - Added SQLite support to the DB helper, including connection handling, schema inspection, identity retrieval, and foreign key discovery.
 - Added SQLite schema/init SQL scripts under App_Data/sql/sqlite and a Users CRUD test that initializes SQLite schema.
 - Added Microsoft.Data.Sqlite package reference for SQLite connectivity.
+- Switched distributed session cache to in-memory when using SQLite to avoid SQL Server cache dependency.
+- Adjusted SQLite foreign key metadata mapping to use string values.
 
 ## Commands that worked (build/test/run)
-- /root/dotnet/dotnet build (failed: libman CDN resolution)
+- /root/dotnet/dotnet build /p:LibraryRestore=false (succeeds; warning in ConvUtilsTests)
 
 ## Pitfalls - fixes
-- dotnet build failed due to libman CDN resolution errors when restoring front-end libraries.
+- dotnet build failed previously due to libman CDN resolution errors when restoring front-end libraries; using LibraryRestore=false allowed build to complete.
 
 ## Decisions - why
 - SQLite schema scripts mirror SQL Server core tables to support local development and tests without SQL Server.
 - Users CRUD test initializes SQLite schema from App_Data/sql/sqlite to validate DB helper + model workflows.
+- SQLite does not ship a built-in distributed cache provider, so sessions use in-memory cache for standalone setups.
 
 ## Heuristics (keep terse)
 - Prefer SQLite PRAGMA introspection for schema and foreign key metadata.

--- a/osafw-app/App_Code/fw/DB.cs
+++ b/osafw-app/App_Code/fw/DB.cs
@@ -2750,12 +2750,12 @@ public class DB : IDisposable
                 result.Add(new DBRow()
                 {
                     { "table", table },
-                    { "column", row["from"] },
-                    { "name", row["id"] },
-                    { "pk_table", row["table"] },
-                    { "pk_column", row["to"] },
-                    { "on_update", row["on_update"] },
-                    { "on_delete", row["on_delete"] }
+                    { "column", row["from"].toStr() },
+                    { "name", row["id"].toStr() },
+                    { "pk_table", row["table"].toStr() },
+                    { "pk_column", row["to"].toStr() },
+                    { "on_update", row["on_update"].toStr() },
+                    { "on_delete", row["on_delete"].toStr() }
                 });
             }
         }

--- a/osafw-app/App_Data/sql/sqlite/demo.sql
+++ b/osafw-app/App_Data/sql/sqlite/demo.sql
@@ -1,0 +1,104 @@
+-- demo tables, use for reference/development, remove when not required
+
+/*Demo Dictionary table*/
+DROP TABLE IF EXISTS demo_dicts;
+CREATE TABLE demo_dicts (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  iname                 TEXT NOT NULL default '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+INSERT INTO demo_dicts (iname, idesc, add_time) VALUES ('test1', 'test1 description', CURRENT_TIMESTAMP);
+INSERT INTO demo_dicts (iname, idesc, add_time) VALUES ('test2', 'test2 description', CURRENT_TIMESTAMP);
+INSERT INTO demo_dicts (iname, idesc, add_time) VALUES ('test3', 'test3 description', CURRENT_TIMESTAMP);
+
+/*Demo table*/
+DROP TABLE IF EXISTS demos;
+CREATE TABLE demos (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  parent_id             INTEGER NOT NULL DEFAULT 0,
+  demo_dicts_id         INTEGER NULL,
+
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+
+  email                 TEXT NOT NULL DEFAULT '',
+
+  fint                  INTEGER NOT NULL DEFAULT 0,
+  ffloat                REAL NOT NULL DEFAULT 0,
+
+  dict_link_auto_id     INTEGER NOT NULL DEFAULT 0,
+  dict_link_multi       TEXT NOT NULL DEFAULT '',
+
+  fcombo                INTEGER NOT NULL DEFAULT 0,
+  fradio                INTEGER NOT NULL DEFAULT 0,
+  fyesno                INTEGER NOT NULL DEFAULT 0,
+  is_checkbox           INTEGER NOT NULL DEFAULT 0,
+
+  fdate_combo           DATE,
+  fdate_pop             DATE,
+  fdatetime             DATETIME,
+  ftime                 INTEGER NOT NULL DEFAULT 0,
+
+  att_id                INTEGER NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (demo_dicts_id) REFERENCES demo_dicts(id),
+  FOREIGN KEY (att_id) REFERENCES att(id)
+);
+CREATE UNIQUE INDEX UX_demos_email ON demos (email);
+CREATE INDEX IX_demos_demo_dicts_id ON demos (demo_dicts_id);
+CREATE INDEX IX_demos_dict_link_auto_id ON demos (dict_link_auto_id);
+
+/*junction table*/
+DROP TABLE IF EXISTS demos_demo_dicts;
+CREATE TABLE demos_demo_dicts (
+  demos_id              INTEGER NULL,
+  demo_dicts_id         INTEGER NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (demos_id) REFERENCES demos(id),
+  FOREIGN KEY (demo_dicts_id) REFERENCES demo_dicts(id)
+);
+CREATE INDEX IX_demos_demo_dicts_demos_id ON demos_demo_dicts (demos_id, demo_dicts_id);
+CREATE INDEX IX_demos_demo_dicts_demo_dicts_id ON demos_demo_dicts (demo_dicts_id, demos_id);
+
+/*subtable for demo items*/
+DROP TABLE IF EXISTS demos_items;
+CREATE TABLE demos_items (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  demos_id              INTEGER NOT NULL,
+
+  demo_dicts_id         INTEGER NULL,
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+  is_checkbox           INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (demos_id) REFERENCES demos(id),
+  FOREIGN KEY (demo_dicts_id) REFERENCES demo_dicts(id)
+);
+CREATE INDEX IX_demos_items_demos_id ON demos_items (demos_id);
+CREATE INDEX IX_demos_items_demo_dicts_id ON demos_items (demo_dicts_id, demos_id);

--- a/osafw-app/App_Data/sql/sqlite/fwdatabase.sql
+++ b/osafw-app/App_Data/sql/sqlite/fwdatabase.sql
@@ -1,0 +1,459 @@
+-- core framework tables only, create app-specific tables in database.sql
+PRAGMA foreign_keys = ON;
+
+/* net core sessions */
+DROP TABLE IF EXISTS fwsessions;
+CREATE TABLE fwsessions (
+  Id                    TEXT NOT NULL PRIMARY KEY,
+  Value                 BLOB NOT NULL,
+  ExpiresAtTime         DATETIME NOT NULL,
+  SlidingExpirationInSeconds INTEGER NULL,
+  AbsoluteExpiration    DATETIME NULL
+);
+CREATE INDEX IX_ExpiresAtTime ON fwsessions (ExpiresAtTime);
+
+/* keys storage */
+DROP TABLE IF EXISTS fwkeys;
+CREATE TABLE fwkeys (
+  iname                 TEXT NOT NULL PRIMARY KEY,
+  itype                 INTEGER NOT NULL DEFAULT 0,
+
+  XmlValue              TEXT NOT NULL,
+
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  upd_time              DATETIME NULL
+);
+CREATE INDEX IX_fwkeys_itype ON fwkeys (itype);
+
+/*application entities lookup - autofilled on demand*/
+DROP TABLE IF EXISTS fwentities;
+CREATE TABLE fwentities (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  icode                 TEXT NOT NULL DEFAULT '',
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_fwentities_icode ON fwentities (icode);
+
+-- for scheduled tasks
+DROP TABLE IF EXISTS fwcron;
+CREATE TABLE fwcron
+(
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  icode                 TEXT NOT NULL DEFAULT '',
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+
+  cron                  TEXT NOT NULL,
+  next_run              DATETIME NULL,
+
+  start_date            DATETIME NULL,
+  end_date              DATETIME NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_fwcron_icode ON fwcron (icode);
+CREATE INDEX IX_fwcron_next_run ON fwcron (next_run);
+
+-- virtual controllers
+DROP TABLE IF EXISTS fwcontrollers;
+CREATE TABLE fwcontrollers
+(
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    
+    icode             TEXT NOT NULL DEFAULT '',
+    url               TEXT NOT NULL DEFAULT '',
+    iname             TEXT NOT NULL DEFAULT '',
+    idesc             TEXT NULL,
+    
+    model             TEXT NOT NULL DEFAULT '',
+    is_lookup         INTEGER NOT NULL DEFAULT 0,
+    igroup            TEXT NOT NULL DEFAULT '',
+    access_level      INTEGER NOT NULL DEFAULT 0,
+    access_level_edit INTEGER NOT NULL DEFAULT 0,
+    
+    config            TEXT NULL,
+    
+    status            INTEGER NOT NULL DEFAULT 0,
+    add_time          DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+    add_users_id      INTEGER DEFAULT 0,
+    upd_time          DATETIME NULL,
+    upd_users_id      INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_fwcontrollers_icode ON fwcontrollers (icode);
+CREATE UNIQUE INDEX UX_fwcontrollers_url ON fwcontrollers (url);
+
+-- track framework database updates
+DROP TABLE IF EXISTS fwupdates;
+CREATE TABLE fwupdates
+(
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    
+    iname        TEXT NOT NULL DEFAULT '',
+    idesc        TEXT NULL,
+    
+    applied_time DATETIME NULL,
+    last_error   TEXT NULL,
+    
+    status       INTEGER NOT NULL DEFAULT 0,
+    add_time     DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+    add_users_id INTEGER DEFAULT 0,
+    upd_time     DATETIME NULL,
+    upd_users_id INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_fwupdates_iname ON fwupdates (iname);
+
+/* upload categories */
+DROP TABLE IF EXISTS att_categories;
+CREATE TABLE att_categories (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  icode                 TEXT NOT NULL DEFAULT '',
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+
+/* attachments - file uploads */
+DROP TABLE IF EXISTS att;
+CREATE TABLE att (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  icode                 TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),
+
+  att_categories_id     INTEGER NULL,
+
+  fwentities_id         INTEGER NULL,
+  item_id               INTEGER NULL,
+
+  is_s3                 INTEGER DEFAULT 0,
+  is_inline             INTEGER DEFAULT 0,
+  is_image              INTEGER DEFAULT 0,
+
+  fname                 TEXT NOT NULL DEFAULT '',
+  fsize                 INTEGER DEFAULT 0,
+  ext                   TEXT NOT NULL DEFAULT '',
+  iname                 TEXT NOT NULL DEFAULT '',
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (att_categories_id) REFERENCES att_categories(id),
+  FOREIGN KEY (fwentities_id) REFERENCES fwentities(id)
+);
+CREATE UNIQUE INDEX UX_att_icode ON att (icode);
+CREATE INDEX IX_att_categories ON att (att_categories_id);
+CREATE INDEX IX_att_fwentities ON att (fwentities_id, item_id);
+
+/*junction to link multiple att files to multiple entity items*/
+DROP TABLE IF EXISTS att_links;
+CREATE TABLE att_links (
+  att_id                INTEGER NOT NULL,
+  fwentities_id         INTEGER NOT NULL,
+  item_id               INTEGER NOT NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (att_id) REFERENCES att(id),
+  FOREIGN KEY (fwentities_id) REFERENCES fwentities(id)
+);
+CREATE UNIQUE INDEX UX_att_links ON att_links (fwentities_id, item_id, att_id);
+CREATE INDEX IX_att_links_att ON att_links (att_id, fwentities_id, item_id);
+
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+  id int PRIMARY KEY AUTOINCREMENT,
+
+  email                 TEXT NOT NULL DEFAULT '',
+  pwd                   TEXT NOT NULL DEFAULT '',
+  access_level          INTEGER NOT NULL,
+  is_readonly           INTEGER NOT NULL DEFAULT 0,
+
+  iname                 TEXT GENERATED ALWAYS AS (fname || ' ' || lname) STORED,
+  fname                 TEXT NOT NULL DEFAULT '',
+  lname                 TEXT NOT NULL DEFAULT '',
+  title                 TEXT NOT NULL DEFAULT '',
+
+  address1              TEXT NOT NULL DEFAULT '',
+  address2              TEXT NOT NULL DEFAULT '',
+  city                  TEXT NOT NULL DEFAULT '',
+  state                 TEXT NOT NULL DEFAULT '',
+  zip                   TEXT NOT NULL DEFAULT '',
+  phone                 TEXT NOT NULL DEFAULT '',
+
+  lang                  TEXT NOT NULL DEFAULT 'en',
+  ui_theme              INTEGER NOT NULL DEFAULT 0,
+  ui_mode               INTEGER NOT NULL DEFAULT 0,
+
+  date_format           INTEGER NOT NULL DEFAULT 0,
+  time_format           INTEGER NOT NULL DEFAULT 0,
+  timezone              TEXT NOT NULL DEFAULT 'UTC',
+
+  idesc                 TEXT,
+  att_id                INTEGER NULL,
+
+  login_time            DATETIME,
+  pwd_reset             TEXT NULL,
+  pwd_reset_time        DATETIME NULL,
+  mfa_secret            TEXT,
+  mfa_recovery          TEXT,
+  mfa_added             DATETIME,
+  login                 TEXT NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (att_id) REFERENCES att(id)
+);
+CREATE UNIQUE INDEX UX_users_email ON users (email);
+CREATE UNIQUE INDEX UX_users_login ON users (login) WHERE login IS NOT NULL;
+
+INSERT INTO users (fname, lname, email, pwd, access_level)
+VALUES ('Website','Admin','admin@admin.com','CHANGE_ME',100);
+
+/*user cookies (for permanent sessions)*/
+DROP TABLE IF EXISTS users_cookies;
+CREATE TABLE users_cookies (
+    cookie_id           TEXT PRIMARY KEY NOT NULL,
+    users_id            INTEGER NOT NULL,
+
+    add_time            DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+
+    FOREIGN KEY (users_id) REFERENCES users(id)
+);
+
+/*Site Settings - special table for misc site settings*/
+DROP TABLE IF EXISTS settings;
+CREATE TABLE settings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  icat                  TEXT NOT NULL DEFAULT '',
+  icode                 TEXT NOT NULL DEFAULT '',
+  ivalue                TEXT NOT NULL DEFAULT '',
+
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+  input                 INTEGER NOT NULL DEFAULT 0,
+  allowed_values        TEXT,
+
+  is_user_edit          INTEGER DEFAULT 0,
+
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_settings_icode ON settings (icode);
+CREATE INDEX IX_settings_icat ON settings (icat);
+INSERT INTO settings (is_user_edit, input, icat, icode, ivalue, iname, idesc) VALUES
+(1, 10, '', 'test', 'novalue', 'test settings', 'description');
+
+/*Static pages*/
+DROP TABLE IF EXISTS spages;
+CREATE TABLE spages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  parent_id             INTEGER NOT NULL DEFAULT 0,
+
+  url                   TEXT NOT NULL DEFAULT '',
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+  head_att_id           INTEGER NULL,
+
+  idesc_left            TEXT,
+  idesc_right           TEXT,
+  meta_keywords         TEXT NOT NULL DEFAULT '',
+  meta_description      TEXT NOT NULL DEFAULT '',
+
+  pub_time              DATETIME,
+  template              TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+  is_home               INTEGER DEFAULT 0,
+  redirect_url          TEXT NOT NULL DEFAULT '',
+
+  custom_head           TEXT,
+  custom_css            TEXT,
+  custom_js             TEXT,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (head_att_id) REFERENCES att(id)
+);
+CREATE INDEX IX_spages_parent_id ON spages (parent_id, prio);
+CREATE INDEX IX_spages_url ON spages (url);
+INSERT INTO spages (parent_id, url, iname) VALUES
+(0,'','Home'),
+(0,'test-page','Test  page');
+UPDATE spages SET is_home=1 WHERE id=1;
+
+/*Logs types*/
+DROP TABLE IF EXISTS log_types;
+CREATE TABLE log_types (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  itype                 INTEGER NOT NULL DEFAULT 0,
+  icode                 TEXT NOT NULL DEFAULT '',
+
+  iname                 TEXT NOT NULL DEFAULT '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE INDEX IX_log_types_icode ON log_types (icode);
+
+/*Activity Logs*/
+DROP TABLE IF EXISTS activity_logs;
+CREATE TABLE activity_logs (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  reply_id              INTEGER NULL,
+  log_types_id          INTEGER NOT NULL,
+  fwentities_id         INTEGER NOT NULL,
+  item_id               INTEGER NULL,
+
+  idate                 DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  users_id              INTEGER NULL,
+  idesc                 TEXT,
+  payload               TEXT,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (log_types_id) REFERENCES log_types(id),
+  FOREIGN KEY (fwentities_id) REFERENCES fwentities(id),
+  FOREIGN KEY (users_id) REFERENCES users(id)
+);
+CREATE INDEX IX_activity_logs_reply_id ON activity_logs (reply_id);
+CREATE INDEX IX_activity_logs_log_types_id ON activity_logs (log_types_id);
+CREATE INDEX IX_activity_logs_fwentities_id ON activity_logs (fwentities_id);
+CREATE INDEX IX_activity_logs_item_id ON activity_logs (item_id);
+CREATE INDEX IX_activity_logs_idate ON activity_logs (idate);
+CREATE INDEX IX_activity_logs_users_id ON activity_logs (users_id);
+
+/*user custom views*/
+DROP TABLE IF EXISTS user_views;
+CREATE TABLE user_views (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  icode                 TEXT NOT NULL,
+  fields                TEXT,
+
+  iname                 TEXT NOT NULL DEFAULT '',
+  is_system             INTEGER NOT NULL DEFAULT 0,
+  is_shared             INTEGER NOT NULL DEFAULT 0,
+  density               TEXT NOT NULL DEFAULT '',
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_user_views ON user_views (add_users_id, icode, iname);
+
+/*user lists*/
+DROP TABLE IF EXISTS user_lists;
+CREATE TABLE user_lists (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity                TEXT NOT NULL,
+
+  iname                 TEXT NOT NULL,
+  idesc                 TEXT,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE INDEX IX_user_lists ON user_lists (add_users_id, entity);
+
+/*items linked to user lists */
+DROP TABLE IF EXISTS user_lists_items;
+CREATE TABLE user_lists_items (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_lists_id         INTEGER NOT NULL,
+  item_id               INTEGER NOT NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (user_lists_id) REFERENCES user_lists(id)
+);
+CREATE UNIQUE INDEX UX_user_lists_items ON user_lists_items (user_lists_id, item_id);
+
+/*Custom menu items for sidebar*/
+DROP TABLE IF EXISTS menu_items;
+CREATE TABLE menu_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  iname                 TEXT NOT NULL default '',
+  url                   TEXT NOT NULL default '',
+  icon                  TEXT NOT NULL default '',
+  controller            TEXT NOT NULL default '',
+  access_level          INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+
+DROP TABLE IF EXISTS user_filters;
+CREATE TABLE user_filters (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  icode                 TEXT NOT NULL,
+
+  iname                 TEXT NOT NULL,
+  idesc                 TEXT,
+  is_system             INTEGER NOT NULL DEFAULT 0,
+  is_shared             INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+
+-- run roles.sql if roles support required and also uncomment #define isRoles in Users model
+
+-- after this file - run lookups.sql

--- a/osafw-app/App_Data/sql/sqlite/lookups.sql
+++ b/osafw-app/App_Data/sql/sqlite/lookups.sql
@@ -1,0 +1,37 @@
+-- fill initial data for lookups here
+
+-- lookups in virtual controllers
+INSERT INTO fwcontrollers (igroup, icode, url, iname, model, access_level)
+VALUES ('System', 'AdminLogTypes', '/Admin/LogTypes', 'Log Types', 'FwLogTypes', 100),
+       ('System', 'AdminAttCategories', '/Admin/AttCategories', 'Upload Categories', 'AttCategories', 50),
+       ('System', 'AdminFwUpdates', '/Admin/FwUpdates', 'FW Updates', 'FwUpdates', 100)
+;
+UPDATE fwcontrollers
+SET is_lookup=1;
+
+-- att_categories
+INSERT INTO att_categories (icode, iname) VALUES
+('general', 'General images')
+,('users', 'Member photos')
+,('files', 'Files')
+,('spage_banner', 'Page banners')
+;
+
+-- log_types
+-- for tracking changes
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'added', 'Record Added');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'updated', 'Record Updated');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'deleted', 'Record Deleted');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'executed', 'Code Executed');
+-- for user login audit
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'login', 'User Login');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'logoff', 'User Logoff');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'login_fail', 'Login Failed');
+INSERT INTO log_types (itype, icode, iname) VALUES (0, 'chpwd', 'User changed login/pwd');
+-- user selectable types
+INSERT INTO log_types (itype, icode, iname) VALUES (10, 'comment', 'Comment');
+
+UPDATE log_types SET prio=id;
+
+-- fwcron tasks
+-- insert into fwcron(icode, cron) values ('example_sleep', '* * * * *') - example task to run every minute

--- a/osafw-app/App_Data/sql/sqlite/roles.sql
+++ b/osafw-app/App_Data/sql/sqlite/roles.sql
@@ -1,0 +1,143 @@
+-- tables for ROLE BASED ACCESS CONTROL (optional)
+/*Resources*/
+DROP TABLE IF EXISTS resources;
+CREATE TABLE resources (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  icode                 TEXT NOT NULL,
+
+  iname                 TEXT NOT NULL default '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_resources_icode ON resources (icode);
+
+/*Permissions*/
+DROP TABLE IF EXISTS permissions;
+CREATE TABLE permissions (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  resources_id          INTEGER NULL,
+  icode                 TEXT NOT NULL,
+
+  iname                 TEXT NOT NULL default '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  FOREIGN KEY (resources_id) REFERENCES resources(id)
+);
+CREATE UNIQUE INDEX UX_permissions_icode ON permissions (icode);
+CREATE INDEX IX_permissions_resources_id ON permissions (resources_id);
+
+/*Roles*/
+DROP TABLE IF EXISTS roles;
+CREATE TABLE roles (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  iname                 TEXT NOT NULL default '',
+  idesc                 TEXT,
+  prio                  INTEGER NOT NULL DEFAULT 0,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0
+);
+CREATE UNIQUE INDEX UX_roles_iname ON roles (iname);
+
+/*Assigned permissions for all roles and resource/permissions*/
+DROP TABLE IF EXISTS roles_resources_permissions;
+CREATE TABLE roles_resources_permissions (
+  roles_id              INTEGER NOT NULL,
+  resources_id          INTEGER NOT NULL,
+  permissions_id        INTEGER NOT NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  PRIMARY KEY (roles_id, resources_id, permissions_id),
+  FOREIGN KEY (roles_id) REFERENCES roles(id),
+  FOREIGN KEY (resources_id) REFERENCES resources(id),
+  FOREIGN KEY (permissions_id) REFERENCES permissions(id)
+);
+CREATE INDEX IX_roles_resources_permissions_resources_id ON roles_resources_permissions (resources_id, roles_id, permissions_id);
+CREATE INDEX IX_roles_resources_permissions_permissions_id ON roles_resources_permissions (permissions_id, roles_id, resources_id);
+CREATE INDEX IX_roles_resources_permissions_rpr ON roles_resources_permissions (resources_id, permissions_id, roles_id);
+
+/*Roles for all users*/
+DROP TABLE IF EXISTS users_roles;
+CREATE TABLE users_roles (
+  users_id              INTEGER NOT NULL,
+  roles_id              INTEGER NOT NULL,
+
+  status                INTEGER NOT NULL DEFAULT 0,
+  add_time              DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  add_users_id          INTEGER DEFAULT 0,
+  upd_time              DATETIME,
+  upd_users_id          INTEGER DEFAULT 0,
+
+  PRIMARY KEY (users_id, roles_id),
+  FOREIGN KEY (users_id) REFERENCES users(id),
+  FOREIGN KEY (roles_id) REFERENCES roles(id)
+);
+CREATE INDEX IX_users_roles_roles_id ON users_roles (roles_id, users_id);
+
+
+--- fill tables
+
+INSERT INTO fwcontrollers (igroup, icode, url, iname, model, access_level)
+VALUES ('RBAC', 'AdminPermissions', '/Admin/Permissions', 'Permissions', 'Permissions', 100),
+       ('RBAC', 'AdminResources', '/Admin/Resources', 'Resources', 'Resources', 100),
+       ('RBAC', 'AdminRoles', '/Admin/Roles', 'Roles', 'Roles', 100);
+
+-- default Permissions
+INSERT INTO permissions (icode, iname) VALUES ('list', 'List');
+INSERT INTO permissions (icode, iname) VALUES ('view', 'View');
+INSERT INTO permissions (icode, iname) VALUES ('add', 'Add');
+INSERT INTO permissions (icode, iname) VALUES ('edit', 'Edit');
+INSERT INTO permissions (icode, iname) VALUES ('del', 'Delete');
+UPDATE permissions SET prio=id;
+
+-- default Roles
+INSERT INTO roles (iname) VALUES ('Admin');
+INSERT INTO roles (iname) VALUES ('Manager');
+INSERT INTO roles (iname) VALUES ('Employee');
+INSERT INTO roles (iname) VALUES ('Customer Service');
+INSERT INTO roles (iname) VALUES ('Vendor');
+INSERT INTO roles (iname) VALUES ('Customer');
+
+-- default Resources
+INSERT INTO resources (icode,iname) VALUES ('Main', 'Main Dashboard');
+INSERT INTO resources (icode,iname) VALUES ('Att', 'Uploads');
+INSERT INTO resources (icode,iname) VALUES ('AdminReports', 'Reports');
+--- optional demo
+INSERT INTO resources (icode,iname) VALUES ('AdminDemos', 'Demo');
+INSERT INTO resources (icode,iname) VALUES ('AdminDemosDynamic', 'Demo Dynamic');
+INSERT INTO resources (icode,iname) VALUES ('AdminDemoDicts', 'Demo Dict');
+--- optional demo end
+INSERT INTO resources (icode,iname) VALUES ('AdminSpages', 'Pages');
+INSERT INTO resources (icode,iname) VALUES ('AdminAtt', 'Manage Uploads');
+INSERT INTO resources (icode,iname) VALUES ('AdminLookupManager', 'Lookup Manager');
+INSERT INTO resources (icode,iname) VALUES ('AdminLookupManagerTables', 'Lookup Manager Table Definitions');
+INSERT INTO resources (icode,iname) VALUES ('AdminRoles', 'Manage Roles');
+INSERT INTO resources (icode,iname) VALUES ('AdminUsers', 'Manage Members');
+INSERT INTO resources (icode,iname) VALUES ('AdminSettings', 'Site Settings');
+INSERT INTO resources (icode,iname) VALUES ('MyViews', 'My Views');
+INSERT INTO resources (icode,iname) VALUES ('MyLists', 'My Lists');
+INSERT INTO resources (icode,iname) VALUES ('MySettings', 'My Profile');
+INSERT INTO resources (icode,iname) VALUES ('MyPassword', 'Change Password');
+UPDATE resources SET prio=id;

--- a/osafw-app/App_Data/sql/sqlite/views.sql
+++ b/osafw-app/App_Data/sql/sqlite/views.sql
@@ -1,0 +1,10 @@
+-- put your custom database views here
+-- delimit sql statements with ";"+newline
+
+-- example:
+-- DROP VIEW IF EXISTS AdminControllerList;
+-- CREATE VIEW AdminControllerList AS
+-- select
+--   *
+-- , SomeNumber*3.14 as CalculatedField
+-- from some_table;

--- a/osafw-app/Program.cs
+++ b/osafw-app/Program.cs
@@ -77,28 +77,36 @@ public static class Program
                 options.XmlRepository = repository; // i.e. "PersistKeysToCustomXmlRepository"
             });
 
+        if (dbType == DB.DBTYPE_SQLITE)
+        {
+            // SQLite does not have a built-in distributed cache provider, use in-memory sessions instead.
+            builder.Services.AddDistributedMemoryCache();
+        }
+        else
+        {
 #if isMySQL
-        // If using MySQL for distributed cache (and sessions)
-        builder.Services.AddDistributedMySqlCache(options =>
-        {
-            var csb = new MySqlConnector.MySqlConnectionStringBuilder(connStr);
-            if (string.IsNullOrEmpty(csb.Database))
-                throw new ApplicationException("No database name defined in connection_string");
+            // If using MySQL for distributed cache (and sessions)
+            builder.Services.AddDistributedMySqlCache(options =>
+            {
+                var csb = new MySqlConnector.MySqlConnectionStringBuilder(connStr);
+                if (string.IsNullOrEmpty(csb.Database))
+                    throw new ApplicationException("No database name defined in connection_string");
 
-            // Setup session store
-            options.ConnectionString = csb.ConnectionString;
-            options.SchemaName = csb.Database; // database name
-            options.TableName = "fwsessions";
-        });
+                // Setup session store
+                options.ConnectionString = csb.ConnectionString;
+                options.SchemaName = csb.Database; // database name
+                options.TableName = "fwsessions";
+            });
 #else
-        // If using SQL Server for distributed cache (and sessions)
-        builder.Services.AddDistributedSqlServerCache(options =>
-        {
-            options.ConnectionString = connStr;
-            options.SchemaName = "dbo";
-            options.TableName = "fwsessions";
-        });
+            // If using SQL Server for distributed cache (and sessions)
+            builder.Services.AddDistributedSqlServerCache(options =>
+            {
+                options.ConnectionString = connStr;
+                options.SchemaName = "dbo";
+                options.TableName = "fwsessions";
+            });
 #endif
+        }
 
         // Form upload/limits
         builder.Services.Configure<FormOptions>(options =>

--- a/osafw-app/osafw-app.csproj
+++ b/osafw-app/osafw-app.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.2" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.69.0" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />

--- a/osafw-tests/UsersSqliteTests.cs
+++ b/osafw-tests/UsersSqliteTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace osafw;
+
+[TestClass]
+public class UsersSqliteTests
+{
+    [TestMethod]
+    public void UsersCrudSqlite()
+    {
+        var repoRoot = FindRepoRoot();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"osafw-test-{Guid.NewGuid():N}.sqlite");
+
+        try
+        {
+            var configuration = BuildTestConfiguration(repoRoot, dbPath);
+            using var fw = FW.initOffline(configuration);
+            InitializeSqliteSchema(fw, repoRoot);
+
+            var users = fw.model<Users>();
+            users.is_log_changes = false;
+
+            var userId = users.add(DB.h(
+                "email", "sqlite@example.com",
+                "pwd", "password123",
+                "fname", "Sql",
+                "lname", "Lite"));
+
+            Assert.IsTrue(userId > 0, "Expected a new user id from insert.");
+
+            var inserted = users.one(userId);
+            Assert.AreEqual("sqlite@example.com", inserted["email"]);
+            Assert.AreEqual("Sql", inserted["fname"]);
+
+            users.update(userId, DB.h("fname", "Updated"));
+            var updated = users.one(userId);
+            Assert.AreEqual("Updated", updated["fname"]);
+
+            users.delete(userId, true);
+            var deleted = users.one(userId);
+            Assert.AreEqual(string.Empty, deleted["email"]);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    private static IConfiguration BuildTestConfiguration(string repoRoot, string dbPath)
+    {
+        return new ConfigurationBuilder()
+            .SetBasePath(repoRoot)
+            .AddJsonFile(Path.Combine(repoRoot, "osafw-app", "appsettings.json"), optional: false, reloadOnChange: false)
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["appSettings:db:main:connection_string"] = $"Data Source={dbPath}",
+                ["appSettings:db:main:type"] = DB.DBTYPE_SQLITE,
+                ["appSettings:db:main:timezone"] = DateUtils.TZ_UTC,
+                ["appSettings:is_test"] = "true"
+            })
+            .Build();
+    }
+
+    private static void InitializeSqliteSchema(FW fw, string repoRoot)
+    {
+        var sqlRoot = Path.Combine(repoRoot, "osafw-app", "App_Data", "sql", "sqlite");
+        var schemaSql = File.ReadAllText(Path.Combine(sqlRoot, "fwdatabase.sql"));
+        fw.db.execMultipleSQL(schemaSql);
+
+        var lookupsSql = File.ReadAllText(Path.Combine(sqlRoot, "lookups.sql"));
+        fw.db.execMultipleSQL(lookupsSql);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "osafw-asp.net-core.sln")))
+            dir = dir.Parent;
+
+        if (dir == null)
+            throw new DirectoryNotFoundException("Unable to locate repository root for osafw-asp.net-core.");
+
+        return dir.FullName;
+    }
+}

--- a/osafw-tests/UsersSqliteTests.cs
+++ b/osafw-tests/UsersSqliteTests.cs
@@ -30,7 +30,7 @@ public class UsersSqliteTests
                 "fname", "Sql",
                 "lname", "Lite"));
 
-            Assert.IsTrue(userId > 0, "Expected a new user id from insert.");
+            Assert.IsGreaterThan(userId, 0, "Expected a new user id from insert.");
 
             var inserted = users.one(userId);
             Assert.AreEqual("sqlite@example.com", inserted["email"]);


### PR DESCRIPTION
### Motivation
- Provide a lightweight local DB option so the framework can run and be tested without SQL Server.
- Enable writing and running automated model/workflow tests using a local SQLite DB for developer and CI scenarios.

### Description
- Extended `DB` to support SQLite by adding `DBTYPE_SQLITE`, `using Microsoft.Data.Sqlite`, connection creation, command/transaction handling, identity retrieval (`last_insert_rowid()`), and timezone fallback logic for SQLite in `osafw-app/App_Code/fw/DB.cs`.
- Implemented SQLite schema introspection via `PRAGMA table_info()` and `PRAGMA foreign_key_list()` and added `mapTypeSQLite2Fw()` to map SQLite type affinities to framework types in `DB.cs`.
- Added SQLite initialization scripts under `osafw-app/App_Data/sql/sqlite/` (`fwdatabase.sql`, `lookups.sql`, `roles.sql`, `demo.sql`, `views.sql`) to initialize core framework tables in SQLite format.
- Added the `Microsoft.Data.Sqlite` package reference to `osafw-app/osafw-app.csproj` and a sample MSTest test `osafw-tests/UsersSqliteTests.cs` that initializes the SQLite schema and exercises `Users` model CRUD flows.

### Testing
- Ran `dotnet build` (`/root/dotnet/dotnet build`), but the build failed during frontend library restore due to `libman.json` CDN resolution errors (unrelated to SQLite code changes); build did not complete and tests were not executed.
- The new SQLite test `UsersSqliteTests` is present and initializes SQLite from `App_Data/sql/sqlite/` and performs insert/update/delete assertions, but it was not run because the build aborted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a7c91f3188330840ae08fb6e2fc9c)