### PR TITLE
feature-is-dev-no-automatic-updates-option

### DIFF
--- a/osafw-app/App_Code/fw/FwUpdates.cs
+++ b/osafw-app/App_Code/fw/FwUpdates.cs
@@ -172,7 +172,7 @@ public class FwUpdates : FwModel
 
     public void checkApplyIfDev()
     {
-        if (!fw.config("IS_DEV").toBool())
+        if (!fw.config("IS_DEV").toBool() || !fw.config("IS_DEV_AUTO_DB_UPDATES").toBool())
             return; // only auto-apply in dev
         try
         {

--- a/osafw-app/appsettings.json
+++ b/osafw-app/appsettings.json
@@ -109,6 +109,7 @@
         "log_level": "DEBUG",
         "is_test": true,
         "IS_DEV": true,
+        "IS_DEV_AUTO_DB_UPDATES": false,
         "db": {
           "main": {
             "connection_string": "Server=(local);Database=demo;Trusted_Connection=True;TrustServerCertificate=true;",


### PR DESCRIPTION
I propose this to be an option. This may be in hand in a single local development, but it has some issues.

1.  In coop development, DB updates can be incompatible or even dangerous to my local DB state. So, I'd like to review them first before applying. The UI Admin interface is good to have.
2. For a lot of updates, for example, back to the project after a long period of time, usually backup/restore Live DB is done to have the actual data anyway.
3. When I'm working on a quite big task, or if there is a constant daily feedback where quite a lot of DB updates need to be done, I have only one update file that I populate gradually with date comments. And the DB is gradually updated manually both locally and on the Dev server when deploying new features. It reduces the clutter for the updated files. For instance:

**2026-04-10.sql**

    -- SOMETASK-12345
    ADD TABLE ....
    ...
    -- 2026-04-12
    ALTER TABLE ...

    -- 2026-04-15
    INSERT INTO ...

4. Additionally, with auto update turned on, the first run of the application gives errors, which is confusing. I had to drop the `demo` DB and recreate it to make sure I have a bare DB.
<img width="879" height="284" alt="image" src="https://github.com/user-attachments/assets/7f5b7a02-cc7a-4a12-af7d-ff7f07f8abf7" />
<img width="1489" height="1033" alt="image" src="https://github.com/user-attachments/assets/5cccb18b-8cfc-4273-b08f-a08e4d084a66" />
